### PR TITLE
Handle case when Github token does not exist

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -109,6 +109,12 @@ func (cli *Client) Request(method string, path string, body io.Reader) ([]byte, 
 
 	if len(cli.login.Token) > 0 {
 		req.Header.Add("X-Barcelona-Token", cli.login.Token)
+	} else {
+		path, err := config.GetConfigPath()
+		if err != nil {
+			panic("Unable to get config path")
+		}
+		return nil, fmt.Errorf("Could not find your Github token inside of %s. Perhaps, you need to run bcn login?", path)
 	}
 
 	return cli.rawRequest(req)

--- a/api/client.go
+++ b/api/client.go
@@ -111,10 +111,11 @@ func (cli *Client) Request(method string, path string, body io.Reader) ([]byte, 
 		req.Header.Add("X-Barcelona-Token", cli.login.Token)
 	} else {
 		path, err := config.GetConfigPath()
+		pathWithLogin := path + "/login"
 		if err != nil {
 			panic("Unable to get config path")
 		}
-		return nil, fmt.Errorf("Could not find your Github token inside of %s. Perhaps, you need to run bcn login?", path)
+		return nil, fmt.Errorf("Could not find your Github token inside of %s\n\nPerhaps, you need to run bcn login?", pathWithLogin)
 	}
 
 	return cli.rawRequest(req)

--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,7 @@ var CertPath string
 var Debug bool
 
 func init() {
-	path, err := getConfigPath()
+	path, err := GetConfigPath()
 	if err != nil {
 		panic("Couldn't get login path")
 	}
@@ -28,7 +28,7 @@ func init() {
 	CertPath = filepath.Join(ConfigDir, "id_ecdsa-cert.pub")
 }
 
-func getConfigPath() (string, error) {
+func GetConfigPath() (string, error) {
 	homedir, err := homedir.Dir()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
The cli will make a request even if a Github token does not exist. The only time a token _shouldn't_ exist is during login ( I think ).

Currently an error message of  "unsupported protocol scheme" is shown to the user. Seen below.

This updates the cli to output the issue and the path where barcelona-cli looks.

![image](https://user-images.githubusercontent.com/1470297/54903300-eb7d9580-4f1e-11e9-967e-113afefd94a5.png)


Final error indication looks like

![image](https://user-images.githubusercontent.com/1470297/54903647-bc1b5880-4f1f-11e9-83e1-5e27addc6f11.png)

