### PR TITLE
Add quiet flag to deploy

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -26,7 +26,7 @@ var DeployCommand = cli.Command{
 		},
 		cli.BoolFlag{
 			Name:  "quiet, q",
-			Usage: "Do not print output if successful"
+			Usage: "Do not print output if successful",
 		},
 	},
 	Action: func(c *cli.Context) error {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -24,11 +24,16 @@ var DeployCommand = cli.Command{
 			Name:  "heritage-token",
 			Usage: "Heritage token",
 		},
+		cli.BoolFlag{
+			Name:  "quiet, q",
+			Usage: "Do not print output if successful"
+		},
 	},
 	Action: func(c *cli.Context) error {
 		env := c.String("environment")
 		tag := c.String("tag")
 		token := c.String("heritage-token")
+		quiet := c.Bool("quiet")
 
 		var heritage *api.Heritage
 		var err error
@@ -41,7 +46,9 @@ var DeployCommand = cli.Command{
 			return cli.NewExitError(err.Error(), 1)
 		}
 
-		PrintHeritage(heritage)
+		if !quiet {
+			PrintHeritage(heritage)
+		}
 
 		return nil
 	},


### PR DESCRIPTION
This PR adds the '-q' flag to the deploy command so the deployment will not echo application secrets during deployment into the CI log files when using `bcn deploy -q`.
