### PR TITLE
Add Gitlab CI Script and Testing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,39 @@
+image: golang:latest
+
+variables:
+  # Please edit to your GitLab project
+  REPO_NAME: github.com/degica/barcelona-cli
+  GLIDE_VERSION: 0.13.3
+
+# The problem is that to be able to use go get, one needs to put
+# the repository in the $GOPATH. So for example if your gitlab domain
+# is gitlab.com, and that your repository is namespace/project, and
+# the default GOPATH being /go, then you'd need to have your
+# repository in /go/src/gitlab.com/namespace/project
+# Thus, making a symbolic link corrects this.
+before_script:
+  - mkdir -p $GOPATH/src/$(dirname $REPO_NAME)
+  - ln -svf $CI_PROJECT_DIR $GOPATH/src/$REPO_NAME
+  - cd $GOPATH/src/$REPO_NAME
+  - wget https://github.com/Masterminds/glide/releases/download/v${GLIDE_VERSION}/glide-v${GLIDE_VERSION}-linux-amd64.tar.gz
+  - tar -xf glide-v${GLIDE_VERSION}-linux-amd64.tar.gz
+  - export PATH="$(pwd)/linux-amd64:$GOPATH/bin:$PATH"
+
+stages:
+  - test
+  - build
+
+test:
+  stage: test
+  script:
+    - make check
+
+build:
+  stage: build
+  script:
+    - pwd
+    - glide install
+    - make
+  artifacts:
+    paths:
+      - bcn

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 .DEFAULT_GOAL := dev
-.PHONY: clean release dev-install dev build generate
+.PHONY: clean release dev-install dev build generate check test format vet
 
 OUTDIR=out
 BINNAME=bcn
 VERSION=$(shell cat ./VERSION)
+PACKAGES=$(shell go list ./... | grep -v /vendor/)
 
 $(OUTDIR)/linux_amd64/bcn:
 	GOOS=linux GOARCH=amd64 go build -o $(OUTDIR)/linux_amd64/bcn
@@ -29,8 +30,20 @@ build: generate $(OUTDIR)/linux_amd64/bcn $(OUTDIR)/darwin_amd64/bcn $(OUTDIR)/w
 
 dev: generate
 	go build -o bcn
+
 install: dev
 	cp ./bcn ~/bin/bcn
+
+check: test format vet
+
+test: generate
+	go test -race $(PACKAGES)
+
+format: generate
+	go fmt $(PACKAGES)
+
+vet: generate
+	go vet $(PACKAGES)
 
 release: build $(OUTDIR)/$(VERSION)/bcn_linux_amd64.tar.gz $(OUTDIR)/$(VERSION)/bcn_darwin_amd64.tar.gz $(OUTDIR)/$(VERSION)/bcn_windows_amd64.zip
 

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -1,0 +1,11 @@
+package api
+
+import "testing"
+
+func TestError(t *testing.T) {
+	var err = APIError{ "errorname", "foobar", []string {} }
+	var result = err.Error()
+	if result != "errorname" {
+		t.Errorf("Expected 'errorname' but got: %s", result)
+	}
+}


### PR DESCRIPTION
bcn cli is lacking automated build and testing. This PR introduces that. It adds a very simple test to demonstrate it and adds a CI script to run tests and attempt to compile the program.

## How to test
1. Install gitlab-runner if you don't already have it
2. Try `gitlab-runner exec docker test`