### PR TITLE
Remove default CPU value

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -163,7 +163,7 @@ func (h *Heritage) FillinDefaults() {
 type Service struct {
 	Public       *bool          `yaml:"public,omitempty" json:"public,omitempty"`
 	Name         string         `yaml:"name" json:"name"`
-	Cpu          int            `yaml:"cpu" json:"cpu"`
+	Cpu          int            `yaml:"cpu" json:"cpu,omitempty"`
 	Memory       int            `yaml:"memory" json:"memory"`
 	Command      string         `yaml:"command" json:"command"`
 	ServiceType  string         `yaml:"service_type" json:"service_type"`
@@ -179,10 +179,6 @@ type Service struct {
 }
 
 func (s *Service) FillinDefaults() {
-	if s.Cpu == 0 {
-		s.Cpu = 512
-	}
-
 	if s.Memory == 0 {
 		s.Memory = 512
 	}


### PR DESCRIPTION
# Context

Currently if you do not define CPU in your `barcelona.yml` the barcelona client will automatically fill it in with a value of 512. Since ECS tasks' CPU parameter is completely optional, this default is actually unnecessary.

This PR removes the default from being set by the client.

Refs https://github.com/degica/barcelona/issues/558