### PR TITLE
Omit cpu if empty for reviewapp

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -101,7 +101,7 @@ type ReviewGroupResponse struct {
 type ReviewAppService struct {
 	Name        string `yaml:"name" json:"name"`
 	ForceSsl    bool   `yaml:"force_ssl" json:"force_ssl"`
-	Cpu         int    `yaml:"cpu" json:"cpu"`
+	Cpu         int    `yaml:"cpu" json:"cpu,omitempty"`
 	Memory      int    `yaml:"memory" json:"memory"`
 	Command     string `yaml:"command" json:"command"`
 	ServiceType string `yaml:"service_type" json:"service_type"`


### PR DESCRIPTION
Previously I removed the CPU default for the deploy command, but the review apps could not deploy with CPU set to 0 since bcn cli still defaulted to 0 if it was omitted from the barcelona.yml.

This change fixes that.

