### PR TITLE
Add run args and accept barcelona yml vars

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -135,6 +135,10 @@ type ReviewAppResponse struct {
 	ReviewApps []*ReviewApp `json:"review_apps,omitempty"`
 }
 
+type RunEnv struct {
+	Vars           map[string]string  `yaml:"vars" json:"vars"`
+}
+
 type Heritage struct {
 	Name           string             `yaml:"name" json:"name"`
 	ImageName      string             `yaml:"image_name" json:"image_name"`
@@ -146,6 +150,7 @@ type Heritage struct {
 	EnvVars        map[string]string  `json:"env_vars,omitempty"`
 	Environment    []*EnvironmentPair `yaml:"environment" json:"environment"`
 	Token          string             `json:"token,omitempty"`
+	RunEnv         *RunEnv            `yaml:"run_env,omitempty" json:"run_env,omitempty"`
 }
 
 func (h *Heritage) FillinDefaults() {

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestCheckEnvVars(t *testing.T) {
+	result, err := checkEnvVars([]string {"ABC=def", "GHI=jkl"})
+
+	if err != nil {
+		t.Errorf("Expected there to be no error but got: %s", err)
+	}
+
+	if result["ABC"] != "def" {
+		t.Errorf("Expected ABC to be set to def but got: %s", result)
+	}
+
+	if result["GHI"] != "jkl" {
+		t.Errorf("Expected ABC to be set to def but got: %s", result)
+	}
+}
+
+func TestCheckEnvVarsError(t *testing.T) {
+	result, err := checkEnvVars([]string {"ABCd=def", "GHI=jkl"})
+
+	if err == nil {
+		t.Errorf("Expected to be an error but was nil")
+	}
+
+	if result != nil {
+		t.Errorf("Expected result to be nil, but was %s", result)
+	}
+
+}


### PR DESCRIPTION
# Context

This PR allows the barcelona.yml to specify environment variables for container s started specially using the `bcn run` command. This will allow specific env vars to be set specifically for humans to operate remote services properly, instead of forcing the human to constantly use the `export` everytime the user needs to do work on the remote machine.

In this change, we add the ability to set a `run_env` for each environment in the barcelona yml file that only gets passed in when `bcn run` is used

This also adds a parameter `-E` to add/overwrite parameters from the barcelona.yml.

Refs #14 

1. Create a barcelona.yml with the following:
```
environments:
  hello:
    name: hello
    image_name: hello_world
    scheduled_tasks: []
    run_env:
      vars:
        ABCDEF: ghi
        HELLO: meow
    services:
      - name: web
        service_type: web
        memory: 256
```
2. Run this command: `bcn -d run -e hello -E HELLO=XD sh`
3. Observe the output contains:
```
{"command":"sh","env_vars":{"ABCDEF":"ghi","HELLO":"XD"},"interactive":true}
```