### PR TITLE
Fix null reference when no env vars defined in yml

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -165,7 +165,7 @@ var RunCommand = cli.Command{
 	},
 }
 
-func loadEnvVars(envName string, heritageName string) (map[string]string, error) {
+func loadEnvVars(envName string) (map[string]string, error) {
 	result := make(map[string]string)
 	if len(envName) > 0 {
 		env, err := LoadEnvironment(envName)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -160,8 +160,10 @@ func loadEnvVars(envName string, heritageName string) (map[string]string, error)
 		if err != nil {
 			return nil, err
 		}
-		for k, v := range env.RunEnv.Vars {
-			result[k] = v
+		if env.RunEnv != nil {
+			for k, v := range env.RunEnv.Vars {
+				result[k] = v
+			}
 		}
 	}
 	return result, nil

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -50,12 +50,23 @@ var RunCommand = cli.Command{
 		detach := c.Bool("detach")
 		envVars := c.StringSlice("envvar")
 		envVarMap, loadEnvVarMapErr := loadEnvVars(envName, heritageName)
+
 		if loadEnvVarMapErr != nil {
 			return cli.NewExitError(loadEnvVarMapErr.Error(), 1)
 		}
+
 		if len(envName) > 0 && len(heritageName) > 0 {
 			return cli.NewExitError("environment and heritage-name are exclusive", 1)
 		}
+
+		if len(heritageName) == 0 {
+			env, err := LoadEnvironment(envName)
+ 			if err != nil {
+ 				return cli.NewExitError(err.Error(), 1)
+ 			}
+			heritageName = env.Name
+		}
+
 		if len(envVars) > 0 {
 			varmap, err := checkEnvVars(envVars)
 			if err != nil {
@@ -65,6 +76,7 @@ var RunCommand = cli.Command{
 				envVarMap[k] = v
 			}
 		}
+
 		if len(c.Args()) == 0 {
 			return cli.NewExitError("Command is required", 1)
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -49,19 +49,12 @@ var RunCommand = cli.Command{
 		heritageName := c.String("heritage-name")
 		detach := c.Bool("detach")
 		envVars := c.StringSlice("envvar")
-		envVarMap := make(map[string]string)
+		envVarMap, loadEnvVarMapErr := loadEnvVars(envName, heritageName)
+		if loadEnvVarMapErr != nil {
+			return cli.NewExitError(loadEnvVarMapErr.Error(), 1)
+		}
 		if len(envName) > 0 && len(heritageName) > 0 {
 			return cli.NewExitError("environment and heritage-name are exclusive", 1)
-		}
-		if len(envName) > 0 {
-			env, err := LoadEnvironment(envName)
-			if err != nil {
-				return cli.NewExitError(err.Error(), 1)
-			}
-			heritageName = env.Name
-			for k, v := range env.RunEnv.Vars {
-				envVarMap[k] = v
-			}
 		}
 		if len(envVars) > 0 {
 			varmap, err := checkEnvVars(envVars)
@@ -158,6 +151,21 @@ var RunCommand = cli.Command{
 
 		return nil
 	},
+}
+
+func loadEnvVars(envName string, heritageName string) (map[string]string, error) {
+	result := make(map[string]string)
+	if len(envName) > 0 {
+		env, err := LoadEnvironment(envName)
+		if err != nil {
+			return nil, err
+		}
+		heritageName = env.Name
+		for k, v := range env.RunEnv.Vars {
+			result[k] = v
+		}
+	}
+	return result, nil
 }
 
 func checkEnvVars(envvarSlice []string) (map[string]string, error) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -160,7 +160,6 @@ func loadEnvVars(envName string, heritageName string) (map[string]string, error)
 		if err != nil {
 			return nil, err
 		}
-		heritageName = env.Name
 		for k, v := range env.RunEnv.Vars {
 			result[k] = v
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -49,7 +49,7 @@ var RunCommand = cli.Command{
 		heritageName := c.String("heritage-name")
 		detach := c.Bool("detach")
 		envVars := c.StringSlice("envvar")
-		envVarMap, loadEnvVarMapErr := loadEnvVars(envName, heritageName)
+		envVarMap, loadEnvVarMapErr := loadEnvVars(envName)
 
 		if loadEnvVarMapErr != nil {
 			return cli.NewExitError(loadEnvVarMapErr.Error(), 1)


### PR DESCRIPTION
This PR fixes a bug introduced in #23 where if you do not define a `run_env` section in the `barcelona.yml` it would throw a null reference error.

## How to test
1. Create a `barcelona.yml` containing this:
```
environments:
  hello:
    name: hello
    image_name: quay.io/dsiawdegica/hello
    scheduled_tasks: []
    services:
      - name: web
        service_type: web
        cpu: null
        memory: 256
        command: sh /start.sh
        listeners:
          - endpoint: hello
            health_check_path: /
        port_mappings:
          - lb_port: 80
            container_port: 8080
            protocol: http
```
2.Run `./bcn -d run -e hello -E FOO=bar` ew
3. Observe that there is no segfault error, and it outputs 

```
{"command":"ew","env_vars":{"FOO":"bar"},"interactive":true}
```