### PR TITLE
Example separation of interface from implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /bcn
 /out
+.DS_Store

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/degica/barcelona-cli/api"
 	"github.com/degica/barcelona-cli/config"
+	"github.com/degica/barcelona-cli/operations"
 	"github.com/urfave/cli"
 )
 
@@ -140,11 +141,8 @@ var LoginCommand = cli.Command{
 			Name:  "info",
 			Usage: "Show login information",
 			Action: func(c *cli.Context) error {
-				login := config.LoadLogin()
-
-				fmt.Printf("Endpoint: %s\n", login.Endpoint)
-				fmt.Printf("Auth:     %s\n", login.Auth)
-				return nil
+				oper := operations.NewLoginInfoOperation()
+				return oper.Run()
 			},
 		},
 	},

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -141,7 +141,7 @@ var LoginCommand = cli.Command{
 			Name:  "info",
 			Usage: "Show login information",
 			Action: func(c *cli.Context) error {
-				oper := operations.NewLoginInfoOperation()
+				oper := operations.NewLoginInfoOperation(config.Get())
 				return oper.Run()
 			},
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,23 @@ var PublicKeyPath string
 var CertPath string
 var Debug bool
 
+// This is the interface clients should use to extract config info
+type Configuration interface {
+	LoadLogin() *Login
+}
+
+// Clients should get configs using this function
+func Get() Configuration {
+	return &localConfig{}
+}
+
+// Implementation of our Configuration object
+type localConfig struct{}
+
+func (m localConfig) LoadLogin() *Login {
+	return LoadLogin()
+}
+
 func init() {
 	path, err := getConfigPath()
 	if err != nil {

--- a/operations/login_info_operation.go
+++ b/operations/login_info_operation.go
@@ -21,7 +21,7 @@ func (oper LoginInfoOperation) Run() error {
 	login := oper.cfg.LoadLogin()
 
 	fmt.Printf("Endpoint: %s\n", login.Endpoint)
-  fmt.Printf("Auth:     %s\n", login.Auth)
+	fmt.Printf("Auth:     %s\n", login.Auth)
 
 	return nil
 }

--- a/operations/login_info_operation.go
+++ b/operations/login_info_operation.go
@@ -1,0 +1,24 @@
+package operations
+
+import (
+	"fmt"
+
+	"github.com/degica/barcelona-cli/config"
+)
+
+type LoginInfoOperation struct {
+}
+
+func NewLoginInfoOperation() *LoginInfoOperation {
+    // set only specific field value with field key
+    return &LoginInfoOperation{}
+}
+
+func (oper LoginInfoOperation) Run() error {
+	login := config.LoadLogin()
+
+	fmt.Printf("Endpoint: %s\n", login.Endpoint)
+  fmt.Printf("Auth:     %s\n", login.Auth)
+
+	return nil
+}

--- a/operations/login_info_operation.go
+++ b/operations/login_info_operation.go
@@ -7,15 +7,18 @@ import (
 )
 
 type LoginInfoOperation struct {
+	cfg config.Configuration
 }
 
-func NewLoginInfoOperation() *LoginInfoOperation {
-    // set only specific field value with field key
-    return &LoginInfoOperation{}
+func NewLoginInfoOperation(cfg config.Configuration) *LoginInfoOperation {
+	// set only specific field value with field key
+	return &LoginInfoOperation{
+		cfg: cfg,
+	}
 }
 
 func (oper LoginInfoOperation) Run() error {
-	login := config.LoadLogin()
+	login := oper.cfg.LoadLogin()
 
 	fmt.Printf("Endpoint: %s\n", login.Endpoint)
   fmt.Printf("Auth:     %s\n", login.Auth)

--- a/operations/login_info_operation_test.go
+++ b/operations/login_info_operation_test.go
@@ -1,0 +1,23 @@
+package operations
+
+import (
+	"github.com/degica/barcelona-cli/config"
+)
+
+type mockConfig struct{}
+
+func (m mockConfig) LoadLogin() *config.Login {
+	return &config.Login{
+		Token:    "",
+		Endpoint: "https://test.example.com",
+	}
+}
+
+func ExampleLoginInfoOperationOutput() {
+
+	op := NewLoginInfoOperation(&mockConfig{})
+	op.Run()
+
+	// Output:
+	// Endpoint: https://test.example.com
+}

--- a/operations/login_info_operation_test.go
+++ b/operations/login_info_operation_test.go
@@ -8,7 +8,7 @@ type mockConfig struct{}
 
 func (m mockConfig) LoadLogin() *config.Login {
 	return &config.Login{
-		Token:    "",
+		Auth: "vault",
 		Endpoint: "https://test.example.com",
 	}
 }
@@ -20,4 +20,5 @@ func ExampleLoginInfoOperation_Run_output() {
 
 	// Output:
 	// Endpoint: https://test.example.com
+	// Auth:     vault
 }

--- a/operations/login_info_operation_test.go
+++ b/operations/login_info_operation_test.go
@@ -8,7 +8,7 @@ type mockConfig struct{}
 
 func (m mockConfig) LoadLogin() *config.Login {
 	return &config.Login{
-		Auth: "vault",
+		Auth:     "vault",
 		Endpoint: "https://test.example.com",
 	}
 }

--- a/operations/login_info_operation_test.go
+++ b/operations/login_info_operation_test.go
@@ -13,7 +13,7 @@ func (m mockConfig) LoadLogin() *config.Login {
 	}
 }
 
-func ExampleLoginInfoOperationOutput() {
+func ExampleLoginInfoOperation_Run_output() {
 
 	op := NewLoginInfoOperation(&mockConfig{})
 	op.Run()


### PR DESCRIPTION
This is an example of separating the CLI from the implementation to better test the CLI. Docbase post:

https://degica.docbase.io/posts/1533621

This is a refactor, but with the addition of tests!