### PR TITLE
Handle the 403 error a bit more properly

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -79,8 +79,8 @@ func (cli *Client) rawRequest(req *http.Request) ([]byte, error) {
 	defer resp.Body.Close()
 
 	if config.Debug {
-		//Is dumping response too much?
-		//dump(httputil.DumpResponse(resp, true))
+		//Is dumping response too much? Probably not.
+		dump(httputil.DumpResponse(resp, true))
 	}
 
 	b, err := ioutil.ReadAll(resp.Body)
@@ -92,6 +92,7 @@ func (cli *Client) rawRequest(req *http.Request) ([]byte, error) {
 		var apiErr APIError
 		err := json.Unmarshal(b, &apiErr)
 		if err != nil {
+			fmt.Printf("Failed to parse error. Use `bcn -d` to see raw server response\n")
 			return nil, err
 		}
 


### PR DESCRIPTION
Previously if your Barcelona server was down, or something else happens and the response is not JSON when you make an API call you get an error like

```
invalid character '<' looking for beginning of value
```

This makes absolutely no sense and confuses the user. This PR adds a message

```
Failed to parse error. Use `bcn -d` to see raw server response
```

To give the user an indication that it may not be his/her fault and provides a way for the user to find out.

Fixes #17 

## How to test
1. Aim your barcelona server somewhere which gives errors by editing `~/.bcn/login` to something like

```
{"token":"abc","endpoint":"https://example.com"}
```

2. Run a command like `bcn api get /meow`
3. Observe the error says parse error failed
4. Try `bcn -d api get /meow` and observe why the response is so
