### PR TITLE
Refactor api operations and handle errors and add tests

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
 
 	"github.com/degica/barcelona-cli/api"
+	"github.com/degica/barcelona-cli/operations"
 	"github.com/urfave/cli"
 )
 
@@ -15,21 +15,10 @@ var APICommand = cli.Command{
 	ArgsUsage: "METHOD PATH [BODY]",
 	Action: func(c *cli.Context) error {
 		method := strings.ToUpper(c.Args().Get(0))
-		if len(method) == 0 {
-			return cli.NewExitError("method is required", 1)
-		}
 		path := c.Args().Get(1)
-		if len(path) == 0 {
-			return cli.NewExitError("path is required", 1)
-		}
 		body := bytes.NewBufferString(c.Args().Get(2))
-		b, err := api.DefaultClient.Request(method, path, body)
-		if err != nil {
-			return cli.NewExitError(err.Error(), 1)
-		}
 
-		fmt.Println(PrettyJSON(b))
-
-		return nil
+		oper := operations.NewApiOperation(method, path, body, api.DefaultClient)
+		return operations.Execute(oper)
 	},
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -142,7 +142,7 @@ var LoginCommand = cli.Command{
 			Usage: "Show login information",
 			Action: func(c *cli.Context) error {
 				oper := operations.NewLoginInfoOperation(config.Get())
-				return oper.Run()
+				return operations.Execute(oper)
 			},
 		},
 	},

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bufio"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -16,19 +15,6 @@ import (
 
 	"github.com/degica/barcelona-cli/api"
 )
-
-func PrettyJSON(b []byte) string {
-	var v interface{}
-	err := json.Unmarshal(b, &v)
-	if err != nil {
-		return ""
-	}
-	pretty, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return ""
-	}
-	return string(pretty)
-}
 
 func PrintHeritage(h *api.Heritage) {
 	fmt.Printf("Name:          %s\n", h.Name)

--- a/operations/api_operation.go
+++ b/operations/api_operation.go
@@ -1,0 +1,47 @@
+package operations
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/degica/barcelona-cli/utils"
+)
+
+type ApiOperationApiClient interface {
+	Request(method string, path string, body io.Reader) ([]byte, error)
+}
+
+type ApiOperation struct {
+	method string
+	path   string
+	body   *bytes.Buffer
+	client ApiOperationApiClient
+}
+
+func NewApiOperation(method string, path string, body *bytes.Buffer, client ApiOperationApiClient) *ApiOperation {
+	return &ApiOperation{
+		method: method,
+		path:   path,
+		body:   body,
+		client: client,
+	}
+}
+
+func (oper ApiOperation) run() *runResult {
+	if len(oper.method) == 0 {
+		return error_result("method is required")
+	}
+	if len(oper.path) == 0 {
+		return error_result("path is required")
+	}
+
+	response, err := oper.client.Request(oper.method, oper.path, oper.body)
+	if err != nil {
+		return error_result(err.Error())
+	}
+
+	fmt.Println(utils.PrettyJSON(response))
+
+	return ok_result()
+}

--- a/operations/api_operation.go
+++ b/operations/api_operation.go
@@ -28,15 +28,15 @@ func NewApiOperation(method string, path string, body *bytes.Buffer, client ApiO
 	}
 }
 
-func (oper ApiOperation) run() *runResult {
-	if len(oper.method) == 0 {
+func (apiOperation ApiOperation) run() *runResult {
+	if len(apiOperation.method) == 0 {
 		return error_result("method is required")
 	}
-	if len(oper.path) == 0 {
+	if len(apiOperation.path) == 0 {
 		return error_result("path is required")
 	}
 
-	response, err := oper.client.Request(oper.method, oper.path, oper.body)
+	response, err := apiOperation.client.Request(apiOperation.method, apiOperation.path, apiOperation.body)
 	if err != nil {
 		return error_result(err.Error())
 	}

--- a/operations/api_operation_test.go
+++ b/operations/api_operation_test.go
@@ -1,0 +1,66 @@
+package operations
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+type MockNormalApiOperationApiClient struct{}
+
+func (client MockNormalApiOperationApiClient) Request(method string, path string, body io.Reader) ([]byte, error) {
+	return bytes.NewBufferString("{\"say\":\"hello\"}").Bytes(), nil
+}
+
+func TestExecutingApiOperation(t *testing.T) {
+	client := &MockNormalApiOperationApiClient{}
+	oper := NewApiOperation("GET", "https://somewhere", bytes.NewBufferString(""), client)
+	result := oper.run()
+
+	if result.is_error != false {
+		t.Errorf("Expected no error to be returned.")
+	}
+}
+
+func ExampleApiOperation_run_output() {
+	client := &MockNormalApiOperationApiClient{}
+	oper := NewApiOperation("GET", "https://somewhere", bytes.NewBufferString(""), client)
+
+	oper.run()
+	// Output:
+	// {
+	//   "say": "hello"
+	// }
+}
+
+type MockApiError struct{}
+
+func (e *MockApiError) Error() string { return "some error msg" }
+
+type MockErrorApiOperationApiClient struct{}
+
+func (client MockErrorApiOperationApiClient) Request(method string, path string, body io.Reader) ([]byte, error) {
+	return nil, &MockApiError{}
+}
+
+func TestExecutingApiOperationReturningError(t *testing.T) {
+	client := &MockErrorApiOperationApiClient{}
+	oper := NewApiOperation("GET", "https://somewhere", bytes.NewBufferString(""), client)
+	result := oper.run()
+
+	if result.is_error != true {
+		t.Errorf("Expected an error to be returned.")
+	}
+
+	if result.message != "some error msg" {
+		t.Errorf("Expected 'some error msg' to be returned. But got %s", result.message)
+	}
+}
+
+func ExampleApiOperation_run_with_error_output() {
+	client := &MockErrorApiOperationApiClient{}
+	oper := NewApiOperation("GET", "https://somewhere", bytes.NewBufferString(""), client)
+
+	oper.run()
+	// Output:
+}

--- a/operations/login_info_operation.go
+++ b/operations/login_info_operation.go
@@ -17,11 +17,11 @@ func NewLoginInfoOperation(cfg config.Configuration) *LoginInfoOperation {
 	}
 }
 
-func (oper LoginInfoOperation) Run() error {
+func (oper LoginInfoOperation) run() *runResult {
 	login := oper.cfg.LoadLogin()
 
 	fmt.Printf("Endpoint: %s\n", login.Endpoint)
 	fmt.Printf("Auth:     %s\n", login.Auth)
 
-	return nil
+	return ok_result()
 }

--- a/operations/login_info_operation_test.go
+++ b/operations/login_info_operation_test.go
@@ -13,10 +13,10 @@ func (m mockConfig) LoadLogin() *config.Login {
 	}
 }
 
-func ExampleLoginInfoOperation_Run_output() {
+func ExampleLoginInfoOperation_run_output() {
 
 	op := NewLoginInfoOperation(&mockConfig{})
-	op.Run()
+	op.run()
 
 	// Output:
 	// Endpoint: https://test.example.com

--- a/operations/operation.go
+++ b/operations/operation.go
@@ -1,0 +1,42 @@
+package operations
+
+import (
+	"github.com/urfave/cli"
+)
+
+type Operation interface {
+	run() *runResult
+}
+
+type runResult struct {
+	is_error bool
+	message  string
+}
+
+func Execute(oper Operation) error {
+	run_result := oper.run()
+
+	if run_result == nil {
+		return nil
+	}
+
+	if run_result.is_error {
+		return cli.NewExitError(run_result.message, 1)
+	}
+
+	return nil
+}
+
+func error_result(message string) *runResult {
+	return &runResult{
+		message:  message,
+		is_error: true,
+	}
+}
+
+func ok_result() *runResult {
+	return &runResult{
+		message:  "",
+		is_error: false,
+	}
+}

--- a/operations/operation_test.go
+++ b/operations/operation_test.go
@@ -1,0 +1,75 @@
+package operations
+
+import (
+	"testing"
+)
+
+type errorOperation struct{}
+
+func (m errorOperation) run() *runResult {
+	return error_result("some error")
+}
+
+func TestExecutingOperationThatReturnsError(t *testing.T) {
+	result := Execute(&errorOperation{})
+
+	if result == nil {
+		t.Errorf("Expected an error to be returned.")
+	}
+
+	if result.Error() != "some error" {
+		t.Errorf("Expected error message to be 'some_error' but got %s", result.Error())
+	}
+}
+
+type nilOperation struct{}
+
+func (m nilOperation) run() *runResult {
+	return nil
+}
+
+func TestExecutingOperationThatReturnsNil(t *testing.T) {
+	result := Execute(&nilOperation{})
+
+	if result != nil {
+		t.Errorf("Expected nil to be returned.")
+	}
+}
+
+type okOperation struct{}
+
+func (m okOperation) run() *runResult {
+	return ok_result()
+}
+
+func TestExecutingOperationThatReturnsOk(t *testing.T) {
+	result := Execute(&okOperation{})
+
+	if result != nil {
+		t.Errorf("Expected nil to be returned.")
+	}
+}
+
+func TestOkResult(t *testing.T) {
+	result := ok_result()
+
+	if result.is_error != false {
+		t.Errorf("Expected is_error to be false but is true")
+	}
+
+	if result.message != "" {
+		t.Errorf("Expected message to be empty string but got %s", result.message)
+	}
+}
+
+func TestErrorResult(t *testing.T) {
+	result := error_result("error message")
+
+	if result.is_error != true {
+		t.Errorf("Expected is_error to be true but is false")
+	}
+
+	if result.message != "error message" {
+		t.Errorf("Expected message to be 'error message' but got %s", result.message)
+	}
+}

--- a/utils/pretty_json.go
+++ b/utils/pretty_json.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"encoding/json"
+)
+
+func PrettyJSON(b []byte) string {
+	var v interface{}
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return ""
+	}
+	pretty, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return ""
+	}
+	return string(pretty)
+}

--- a/utils/pretty_json_test.go
+++ b/utils/pretty_json_test.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// Please note that I used examples here to assert output
+// because its easier to read than a heavily escaped string
+
+func ExamplePrettyJSON_output() {
+	data := bytes.NewBufferString("{\"cat\":\"meow\"}").Bytes()
+	result := PrettyJSON(data)
+
+	fmt.Println(result)
+
+	// Output:
+	// {
+	//   "cat": "meow"
+	// }
+}
+
+func ExamplePrettyJSON_notjson() {
+	data := bytes.NewBufferString("<garbage>").Bytes()
+	result := PrettyJSON(data)
+
+	fmt.Println(result)
+
+	// Output:
+	//
+}
+
+func ExamplePrettyJSON_empty() {
+	data := bytes.NewBufferString("").Bytes()
+	result := PrettyJSON(data)
+
+	fmt.Println(result)
+
+	// Output:
+	//
+}


### PR DESCRIPTION
As a task for Refactor Tuesday I wanted to attempt doing this: https://degica.docbase.io/posts/1533621

I however learned that the document did not offer a solution for when the operation could throw errors and took parameters, so I refactored the Api Operation to start with to lay the general groundwork from which all other operations should be refactored.

This PR also includes a small refactor of prettyJSON function out to an utils package, and tests it.

This is a refactor so it should work as it always has before. Unfortunately we are still a little thin on tests, and hopefully this PR improves things for any future changes.

To reviewers: feel free to ask any questions about golang. I can jump on a call to explain things to expedite the review process, as most of us are understandably unfamiliar with golang.