### PR TITLE
More testing

### DIFF
--- a/api/heritage.go
+++ b/api/heritage.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 )
 
 func (cli *Client) CreateHeritage(districtName string, h *Heritage) (*Heritage, error) {
@@ -22,4 +23,26 @@ func (cli *Client) CreateHeritage(districtName string, h *Heritage) (*Heritage, 
 	}
 
 	return hResp.Heritage, nil
+}
+
+func (h *Heritage) Print() {
+	fmt.Printf("Name:          %s\n", h.Name)
+	fmt.Printf("Image Name:    %s\n", h.ImageName)
+	fmt.Printf("Image Tag :    %s\n", h.ImageTag)
+	fmt.Printf("Version:       %d\n", h.Version)
+	if h.BeforeDeploy != nil {
+		fmt.Printf("Before Deploy: %s\n", *h.BeforeDeploy)
+	} else {
+		fmt.Printf("Before Deploy: None\n")
+	}
+	fmt.Printf("Token:         %s\n", h.Token)
+	fmt.Printf("Scheduled Tasks:\n")
+	for _, task := range h.ScheduledTasks {
+		fmt.Printf("%-20s %s\n", task.Schedule, task.Command)
+	}
+
+	fmt.Printf("Environment Variables\n")
+	for name, value := range h.EnvVars {
+		fmt.Printf("  %s: %s\n", name, value)
+	}
 }

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/degica/barcelona-cli/api"
+	"github.com/degica/barcelona-cli/operations"
+	"github.com/degica/barcelona-cli/utils"
 	"github.com/urfave/cli"
 )
 
@@ -23,22 +22,9 @@ var AppCommand = cli.Command{
 			},
 			Action: func(c *cli.Context) error {
 				name := c.Args().Get(0)
-				if len(name) == 0 {
-					return cli.NewExitError("district name is required", 1)
-				}
 
-				fmt.Printf("You are attempting to delete %s\n", name)
-				if !c.Bool("no-confirmation") && !areYouSure("This operation cannot be undone. Are you sure?") {
-					return nil
-				}
-
-				_, err := api.DefaultClient.Delete("/heritages/"+name, nil)
-				if err != nil {
-					return cli.NewExitError(err.Error(), 1)
-				}
-				fmt.Printf("Deleted %s\n", name)
-
-				return nil
+				oper := operations.NewAppOperation(name, operations.Delete, c.Bool("no-confirmation"), api.DefaultClient, utils.NewStdinInputReader())
+				return operations.Execute(oper)
 			},
 		},
 		{
@@ -47,22 +33,9 @@ var AppCommand = cli.Command{
 			ArgsUsage: "HERITAGE_NAME",
 			Action: func(c *cli.Context) error {
 				name := c.Args().Get(0)
-				if len(name) == 0 {
-					return cli.NewExitError("district name is required", 1)
-				}
 
-				resp, err := api.DefaultClient.Get("/heritages/"+name, nil)
-				if err != nil {
-					return cli.NewExitError(err.Error(), 1)
-				}
-				var hResp api.HeritageResponse
-				err = json.Unmarshal(resp, &hResp)
-				if err != nil {
-					return cli.NewExitError(err.Error(), 1)
-				}
-				PrintHeritage(hResp.Heritage)
-
-				return nil
+				oper := operations.NewAppOperation(name, operations.Show, false, api.DefaultClient, utils.NewStdinInputReader())
+				return operations.Execute(oper)
 			},
 		},
 	},

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -36,7 +36,7 @@ var CreateCommand = cli.Command{
 		if err != nil {
 			return cli.NewExitError(err.Error(), 1)
 		}
-		PrintHeritage(resp)
+		resp.Print()
 
 		return nil
 	},

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -47,7 +47,7 @@ var DeployCommand = cli.Command{
 		}
 
 		if !quiet {
-			PrintHeritage(heritage)
+			heritage.Print()
 		}
 
 		return nil

--- a/cmd/district.go
+++ b/cmd/district.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/degica/barcelona-cli/api"
+	"github.com/degica/barcelona-cli/utils"
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli"
 )
@@ -53,8 +54,8 @@ var DistrictCommand = cli.Command{
 					ClusterInstanceType: c.String("cluster-instance-type"),
 					ClusterBackend:      "autoscaling",
 				}
-				request.AwsAccessKeyId = ask("AWS Access Key ID", true, false)
-				request.AwsSecretAccessKey = ask("AWS Secret Access Key", true, true)
+				request.AwsAccessKeyId = utils.Ask("AWS Access Key ID", true, false, utils.NewStdinInputReader())
+				request.AwsSecretAccessKey = utils.Ask("AWS Secret Access Key", true, true, utils.NewStdinInputReader())
 
 				district, err := api.DefaultClient.CreateDistrict(&request)
 				if err != nil {
@@ -184,7 +185,7 @@ var DistrictCommand = cli.Command{
 				}
 
 				fmt.Printf("You are attempting to delete %s\n", districtName)
-				if !c.Bool("no-confirmation") && !areYouSure("This operation cannot be undone. Are you sure?") {
+				if !c.Bool("no-confirmation") && !utils.AreYouSure("This operation cannot be undone. Are you sure?", utils.NewStdinInputReader()) {
 					return nil
 				}
 

--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/degica/barcelona-cli/api"
+	"github.com/degica/barcelona-cli/utils"
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli"
 )
@@ -197,7 +198,7 @@ var EndpointCommand = cli.Command{
 				}
 
 				fmt.Printf("You are attempting to delete /%s/endpoints/%s\n", c.String("district"), endpointName)
-				if !c.Bool("no-confirmation") && !areYouSure("This operation cannot be undone. Are you sure?") {
+				if !c.Bool("no-confirmation") && !utils.AreYouSure("This operation cannot be undone. Are you sure?", utils.NewStdinInputReader()) {
 					return nil
 				}
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -12,6 +12,7 @@ import (
 	"github.com/degica/barcelona-cli/api"
 	"github.com/degica/barcelona-cli/config"
 	"github.com/degica/barcelona-cli/operations"
+	"github.com/degica/barcelona-cli/utils"
 	"github.com/urfave/cli"
 )
 
@@ -50,7 +51,7 @@ var LoginCommand = cli.Command{
 			token := c.String("github-token")
 			if len(token) == 0 {
 				fmt.Println("Create new GitHub access token with read:org permission here https://github.com/settings/tokens/new")
-				token = ask("GitHub Token", true, true)
+				token = utils.Ask("GitHub Token", true, true, utils.NewStdinInputReader())
 			}
 
 			user, err = api.DefaultClient.LoginWithGithub(endpoint, token)
@@ -72,7 +73,7 @@ var LoginCommand = cli.Command{
 			vaultToken := c.String("vault-token")
 			if len(vaultToken) == 0 {
 				fmt.Println("Create new GitHub access token with read:org permission here https://github.com/settings/tokens/new")
-				vaultToken = ask("GitHub Token", true, true)
+				vaultToken = utils.Ask("GitHub Token", true, true, utils.NewStdinInputReader())
 			}
 			user, err = api.DefaultClient.LoginWithVault(endpoint, vaultToken)
 			if err != nil {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -1,42 +1,15 @@
 package cmd
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strings"
-	"syscall"
 
 	yaml "gopkg.in/yaml.v2"
 
-	"golang.org/x/crypto/ssh/terminal"
-
 	"github.com/degica/barcelona-cli/api"
 )
-
-func PrintHeritage(h *api.Heritage) {
-	fmt.Printf("Name:          %s\n", h.Name)
-	fmt.Printf("Image Name:    %s\n", h.ImageName)
-	fmt.Printf("Image Tag :    %s\n", h.ImageTag)
-	fmt.Printf("Version:       %d\n", h.Version)
-	if h.BeforeDeploy != nil {
-		fmt.Printf("Before Deploy: %s\n", *h.BeforeDeploy)
-	} else {
-		fmt.Printf("Before Deploy: None\n")
-	}
-	fmt.Printf("Token:         %s\n", h.Token)
-	fmt.Printf("Scheduled Tasks:\n")
-	for _, task := range h.ScheduledTasks {
-		fmt.Printf("%-20s %s\n", task.Schedule, task.Command)
-	}
-
-	fmt.Printf("Environment Variables\n")
-	for name, value := range h.EnvVars {
-		fmt.Printf("  %s: %s\n", name, value)
-	}
-}
 
 func PrintOneoff(o *api.Oneoff) {
 	fmt.Printf("Task ARN: %s\n", o.TaskARN)
@@ -45,49 +18,6 @@ func PrintOneoff(o *api.Oneoff) {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
-}
-
-func ask(s string, required bool, secret bool) string {
-
-	var response string
-	var err error
-	for {
-		fmt.Printf("%s: ", s)
-
-		if secret {
-			bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
-			if err != nil {
-				continue
-			}
-			fmt.Printf("\n")
-			response = string(bytePassword)
-		} else {
-			reader := bufio.NewReader(os.Stdin)
-			response, err = reader.ReadString('\n')
-			if err != nil {
-				continue
-			}
-		}
-		response = strings.TrimSpace(response)
-
-		if len(response) == 0 && required {
-			continue
-		}
-		break
-	}
-
-	return response
-}
-
-func areYouSure(message string) bool {
-	for {
-		res := ask(fmt.Sprintf("%s [y/n]", message), false, false)
-		if res == "y" {
-			return true
-		} else if res == "n" {
-			return false
-		}
-	}
 }
 
 type HeritageConfig struct {

--- a/operations/app_operation.go
+++ b/operations/app_operation.go
@@ -1,0 +1,83 @@
+package operations
+
+import (
+	"fmt"
+	"io"
+
+	"encoding/json"
+
+	"github.com/degica/barcelona-cli/api"
+	"github.com/degica/barcelona-cli/utils"
+)
+
+type AppOperationApiClient interface {
+	Get(path string, body io.Reader) ([]byte, error)
+	Delete(path string, body io.Reader) ([]byte, error)
+}
+
+type AppOperation struct {
+	name         string
+	optype       OperationType
+	no_confirm   bool
+	client       AppOperationApiClient
+	input_reader utils.UserInputReader
+}
+
+func NewAppOperation(name string, optype OperationType, no_confirm bool, client AppOperationApiClient, input_reader utils.UserInputReader) *AppOperation {
+	return &AppOperation{
+		name:         name,
+		optype:       optype,
+		no_confirm:   no_confirm,
+		client:       client,
+		input_reader: input_reader,
+	}
+}
+
+func app_delete(oper AppOperation) *runResult {
+	fmt.Printf("You are attempting to delete %s\n", oper.name)
+	if !oper.no_confirm && !utils.AreYouSure("This operation cannot be undone. Are you sure?", oper.input_reader) {
+		return nil
+	}
+
+	_, err := oper.client.Delete("/heritages/"+oper.name, nil)
+	if err != nil {
+		return error_result(err.Error())
+	}
+	fmt.Printf("Deleted %s\n", oper.name)
+
+	return ok_result()
+}
+
+func app_show(oper AppOperation) *runResult {
+	resp, err := oper.client.Get("/heritages/"+oper.name, nil)
+	if err != nil {
+		return error_result(err.Error())
+	}
+	var hResp api.HeritageResponse
+	err = json.Unmarshal(resp, &hResp)
+	if err != nil {
+		return error_result(err.Error())
+	}
+	if hResp.Heritage == nil {
+		return error_result("No such heritage")
+	}
+	hResp.Heritage.Print()
+
+	return ok_result()
+}
+
+func (oper AppOperation) run() *runResult {
+	if len(oper.name) == 0 {
+		return error_result("district name is required")
+	}
+
+	if oper.optype == Delete {
+		return app_delete(oper)
+	}
+
+	if oper.optype == Show {
+		return app_show(oper)
+	}
+
+	return error_result("unknown operation")
+}

--- a/operations/app_operation.go
+++ b/operations/app_operation.go
@@ -17,39 +17,39 @@ type AppOperationApiClient interface {
 
 type AppOperation struct {
 	name         string
-	optype       OperationType
+	op_type      OperationType
 	no_confirm   bool
 	client       AppOperationApiClient
 	input_reader utils.UserInputReader
 }
 
-func NewAppOperation(name string, optype OperationType, no_confirm bool, client AppOperationApiClient, input_reader utils.UserInputReader) *AppOperation {
+func NewAppOperation(name string, op_type OperationType, no_confirm bool, client AppOperationApiClient, input_reader utils.UserInputReader) *AppOperation {
 	return &AppOperation{
 		name:         name,
-		optype:       optype,
+		op_type:      op_type,
 		no_confirm:   no_confirm,
 		client:       client,
 		input_reader: input_reader,
 	}
 }
 
-func app_delete(oper AppOperation) *runResult {
-	fmt.Printf("You are attempting to delete %s\n", oper.name)
-	if !oper.no_confirm && !utils.AreYouSure("This operation cannot be undone. Are you sure?", oper.input_reader) {
+func app_delete(operation AppOperation) *runResult {
+	fmt.Printf("You are attempting to delete %s\n", operation.name)
+	if !operation.no_confirm && !utils.AreYouSure("This operation cannot be undone. Are you sure?", operation.input_reader) {
 		return nil
 	}
 
-	_, err := oper.client.Delete("/heritages/"+oper.name, nil)
+	_, err := operation.client.Delete("/heritages/"+operation.name, nil)
 	if err != nil {
 		return error_result(err.Error())
 	}
-	fmt.Printf("Deleted %s\n", oper.name)
+	fmt.Printf("Deleted %s\n", operation.name)
 
 	return ok_result()
 }
 
-func app_show(oper AppOperation) *runResult {
-	resp, err := oper.client.Get("/heritages/"+oper.name, nil)
+func app_show(operation AppOperation) *runResult {
+	resp, err := operation.client.Get("/heritages/"+operation.name, nil)
 	if err != nil {
 		return error_result(err.Error())
 	}
@@ -66,17 +66,17 @@ func app_show(oper AppOperation) *runResult {
 	return ok_result()
 }
 
-func (oper AppOperation) run() *runResult {
-	if len(oper.name) == 0 {
+func (operation AppOperation) run() *runResult {
+	if len(operation.name) == 0 {
 		return error_result("district name is required")
 	}
 
-	if oper.optype == Delete {
-		return app_delete(oper)
+	if operation.op_type == Delete {
+		return app_delete(operation)
 	}
 
-	if oper.optype == Show {
-		return app_show(oper)
+	if operation.op_type == Show {
+		return app_show(operation)
 	}
 
 	return error_result("unknown operation")

--- a/operations/app_operation_test.go
+++ b/operations/app_operation_test.go
@@ -1,0 +1,69 @@
+package operations
+
+import (
+	"bytes"
+	"io"
+)
+
+type MockAppOperationApiClient struct {
+}
+
+func (client MockAppOperationApiClient) Get(path string, body io.Reader) ([]byte, error) {
+	return bytes.NewBufferString("{\"say\":\"hello\"}").Bytes(), nil
+}
+
+func (client MockAppOperationApiClient) Delete(path string, body io.Reader) ([]byte, error) {
+	return bytes.NewBufferString("").Bytes(), nil
+}
+
+type MockAppOperationInputReaderNo struct {
+}
+
+func (_ MockAppOperationInputReaderNo) Read(_ bool) (string, error) {
+	return "n\n", nil
+}
+
+type MockAppOperationInputReaderYes struct {
+}
+
+func (_ MockAppOperationInputReaderYes) Read(_ bool) (string, error) {
+	return "y\n", nil
+}
+
+func ExampleAppOperation_run_delete_no_confirm_output() {
+	client := &MockAppOperationApiClient{}
+	oper := NewAppOperation("asd", Delete, true, client, nil /* because it doesnt matter */)
+
+	oper.run()
+	// Output:
+	// You are attempting to delete asd
+	// Deleted asd
+}
+
+func ExampleAppOperation_run_delete_confirm_y_output() {
+	client := &MockAppOperationApiClient{}
+	oper := NewAppOperation("asd", Delete, false, client, &MockAppOperationInputReaderYes{})
+
+	oper.run()
+	// Output:
+	// You are attempting to delete asd
+	// This operation cannot be undone. Are you sure? [y/n]: Deleted asd
+}
+
+func ExampleAppOperation_run_delete_confirm_n_output() {
+	client := &MockAppOperationApiClient{}
+	oper := NewAppOperation("asd", Delete, false, client, &MockAppOperationInputReaderNo{})
+
+	oper.run()
+	// Output:
+	// You are attempting to delete asd
+	// This operation cannot be undone. Are you sure? [y/n]:
+}
+
+func ExampleAppOperation_run_show_output_when_no_heritage() {
+	client := &MockAppOperationApiClient{}
+	oper := NewAppOperation("asd", Show, true, client, &MockAppOperationInputReaderYes{})
+
+	oper.run()
+	// Output:
+}

--- a/operations/operation.go
+++ b/operations/operation.go
@@ -40,3 +40,10 @@ func ok_result() *runResult {
 		is_error: false,
 	}
 }
+
+type OperationType string
+
+const (
+	Delete OperationType = "Delete"
+	Show                 = "Show"
+)

--- a/utils/are_you_sure.go
+++ b/utils/are_you_sure.go
@@ -28,25 +28,20 @@ func (reader StdinInputReader) Read(secret bool) (string, error) {
 		}
 		response := string(bytePassword)
 		return response, nil
-
-	} else {
-		reader := bufio.NewReader(os.Stdin)
-		response, err := reader.ReadString('\n')
-		if err != nil {
-			return "", err
-		}
-		return response, nil
 	}
+
+	stdin_reader := bufio.NewReader(os.Stdin)
+	response, err := stdin_reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	return response, nil
 }
 
 func AreYouSure(message string, reader UserInputReader) bool {
 	for {
 		res := Ask(fmt.Sprintf("%s [y/n]", message), false, false, reader)
-		if res == "y" {
-			return true
-		} else if res == "n" {
-			return false
-		}
+		return res == "y"
 	}
 }
 

--- a/utils/are_you_sure.go
+++ b/utils/are_you_sure.go
@@ -1,0 +1,72 @@
+package utils
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+type UserInputReader interface {
+	Read(secret bool) (string, error)
+}
+
+type StdinInputReader struct{}
+
+func NewStdinInputReader() *StdinInputReader {
+	return &StdinInputReader{}
+}
+
+func (reader StdinInputReader) Read(secret bool) (string, error) {
+	if secret {
+		bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			return "", err
+		}
+		response := string(bytePassword)
+		return response, nil
+
+	} else {
+		reader := bufio.NewReader(os.Stdin)
+		response, err := reader.ReadString('\n')
+		if err != nil {
+			return "", err
+		}
+		return response, nil
+	}
+}
+
+func AreYouSure(message string, reader UserInputReader) bool {
+	for {
+		res := Ask(fmt.Sprintf("%s [y/n]", message), false, false, reader)
+		if res == "y" {
+			return true
+		} else if res == "n" {
+			return false
+		}
+	}
+}
+
+func Ask(s string, required bool, secret bool, reader UserInputReader) string {
+	var response string
+	var err error
+	for {
+		fmt.Printf("%s: ", s)
+
+		response, err = reader.Read(secret)
+		response = strings.TrimSpace(response)
+
+		if err != nil {
+			continue
+		}
+		if len(response) == 0 && required {
+			continue
+		}
+		break
+	}
+
+	return response
+}


### PR DESCRIPTION
This PR moves a bunch of the `app` command out to its own operation and stubs out a bunch of things that it uses in order to enable testing on it. Yes that includes testing user input

Additionally, the following changes are made:

- Make `Print` a member of `Heritage` instead of `PrintHeritage`
- Moved User input commands into the utils package
- Create a `utils.UserInputReader` interface that allows me to stub out user input and test behaviour for various kinds of input.

As with other parts of barcelona-cli, there is some heavy golang action here so feel free to ask any questions.