### PR TITLE
Login vault

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -27,7 +27,7 @@ var pathPrefix = "/v1"
 var DefaultClient *Client
 
 func init() {
-	err := ReloadDefaultClient()
+	err := reloadDefaultClient()
 	if err != nil {
 		panic("Couldn't initialize default client: " + err.Error())
 	}
@@ -52,7 +52,7 @@ func newDefaultClient() (*Client, error) {
 	return cli, nil
 }
 
-func ReloadDefaultClient() error {
+func reloadDefaultClient() error {
 	cli, err := newDefaultClient()
 	if err != nil {
 		return err
@@ -101,20 +101,26 @@ func (cli *Client) rawRequest(req *http.Request) ([]byte, error) {
 	return b, nil
 }
 
+func (cli *Client) ReloadDefaultClient() (*Client, error) {
+	err := reloadDefaultClient()
+	return DefaultClient, err
+}
+
 func (cli *Client) Request(method string, path string, body io.Reader) ([]byte, error) {
-	url := cli.login.Endpoint + pathPrefix + path
+	url := cli.login.GetEndpoint() + pathPrefix + path
+
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return nil, err
 	}
 
-	switch cli.login.Auth {
+	switch cli.login.GetAuth() {
 	case "github":
-		if len(cli.login.Token) > 0 {
-			req.Header.Add("X-Barcelona-Token", cli.login.Token)
+		if len(cli.login.GetToken()) > 0 {
+			req.Header.Add("X-Barcelona-Token", cli.login.GetToken())
 		}
 	case "vault":
-		req.Header.Add("X-Vault-Token", cli.login.Token)
+		req.Header.Add("X-Vault-Token", cli.login.GetToken())
 	}
 
 	return cli.rawRequest(req)

--- a/api/login.go
+++ b/api/login.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -36,9 +37,14 @@ func (cli *Client) LoginWithVault(endpoint string, vault_url string, githubToken
 		return nil, err
 	}
 	b, err := cli.rawRequest(req)
+	if err != nil {
+		return nil, err
+	}
 
 	var resp VaultAuthResponse
 	json.Unmarshal(b, &resp)
+
+	fmt.Println(b)
 
 	user := &User{
 		Token:     resp.Auth.ClientToken,

--- a/api/login.go
+++ b/api/login.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -28,29 +27,22 @@ func (cli *Client) LoginWithGithub(endpoint string, githubToken string) (*User, 
 	return userResp.User, nil
 }
 
-func (cli *Client) LoginWithVault(endpoint string, vault_url string, githubToken string) (*User, error) {
-
+func (cli *Client) LoginWithVault(vault_url string, githubToken string) (*User, error) {
 	req, err := http.NewRequest("POST",
 		vault_url+"/v1/auth/github/login",
 		strings.NewReader("{\"token\":\""+githubToken+"\"}"))
 	if err != nil {
 		return nil, err
 	}
-	b, err := cli.rawRequest(req)
+	rawResponse, err := cli.rawRequest(req)
 	if err != nil {
 		return nil, err
 	}
 
 	var resp VaultAuthResponse
-	json.Unmarshal(b, &resp)
+	json.Unmarshal(rawResponse, &resp)
 
-	fmt.Println(b)
-
-	user := &User{
-		Token:     resp.Auth.ClientToken,
-		Name:      "",
-		PublicKey: "",
-	}
+	user := &User{Token: resp.Auth.ClientToken}
 
 	return user, nil
 }

--- a/api/types.go
+++ b/api/types.go
@@ -300,6 +300,14 @@ type APIError struct {
 	Backtrace    []string `json:"backtrace"`
 }
 
+type VaultAuthResponseAuth struct {
+	ClientToken string `json:"client_token"`
+}
+
+type VaultAuthResponse struct {
+	Auth VaultAuthResponseAuth `json:"auth"`
+}
+
 func (err *APIError) Error() string {
 	if config.Debug {
 		return fmt.Sprintf("%s\n\n%s\n%s\n", err.Message, err.DebugMessage, strings.Join(err.Backtrace, "\n"))

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -51,6 +51,7 @@ var LoginCommand = cli.Command{
 		}
 
 		oper := operations.NewLoginOperation(endpoint, backend, gh_token, vault_token, vault_url, ext)
+
 		return operations.Execute(oper)
 	},
 	Subcommands: []cli.Command{

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -43,11 +43,13 @@ var LoginCommand = cli.Command{
 			*api.Client
 			*config.LocalConfig
 			*utils.CommandRunner
+			*utils.FileOps
 		}{
 			utils.NewStdinInputReader(),
 			api.DefaultClient,
 			config.Get(),
 			&utils.CommandRunner{},
+			&utils.FileOps{},
 		}
 
 		oper := operations.NewLoginOperation(endpoint, backend, gh_token, vault_token, vault_url, ext)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -4,6 +4,7 @@ import (
 	"github.com/degica/barcelona-cli/api"
 	"github.com/degica/barcelona-cli/config"
 	"github.com/degica/barcelona-cli/operations"
+	"github.com/degica/barcelona-cli/utils"
 	"github.com/urfave/cli"
 )
 
@@ -37,7 +38,19 @@ var LoginCommand = cli.Command{
 		vault_token := c.String("vault-token")
 		vault_url := c.String("vault-url")
 
-		oper := operations.NewLoginOperation(endpoint, backend, gh_token, vault_token, vault_url, api.DefaultClient, config.Get())
+		ext := struct {
+			utils.UserInputReader
+			*api.Client
+			*config.LocalConfig
+			*utils.CommandRunner
+		}{
+			utils.NewStdinInputReader(),
+			api.DefaultClient,
+			config.Get(),
+			&utils.CommandRunner{},
+		}
+
+		oper := operations.NewLoginOperation(endpoint, backend, gh_token, vault_token, vault_url, ext)
 		return operations.Execute(oper)
 	},
 	Subcommands: []cli.Command{

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -51,7 +51,6 @@ var LoginCommand = cli.Command{
 		}
 
 		oper := operations.NewLoginOperation(endpoint, backend, gh_token, vault_token, vault_url, ext)
-
 		return operations.Execute(oper)
 	},
 	Subcommands: []cli.Command{

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -52,16 +52,16 @@ var LoginCommand = cli.Command{
 			&utils.FileOps{},
 		}
 
-		oper := operations.NewLoginOperation(endpoint, backend, gh_token, vault_token, vault_url, ext)
-		return operations.Execute(oper)
+		operation := operations.NewLoginOperation(endpoint, backend, gh_token, vault_token, vault_url, ext)
+		return operations.Execute(operation)
 	},
 	Subcommands: []cli.Command{
 		{
 			Name:  "info",
 			Usage: "Show login information",
 			Action: func(c *cli.Context) error {
-				oper := operations.NewLoginInfoOperation(config.Get())
-				return operations.Execute(oper)
+				operation := operations.NewLoginInfoOperation(config.Get())
+				return operations.Execute(operation)
 			},
 		},
 	},

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -40,13 +40,13 @@ var LoginCommand = cli.Command{
 
 		ext := struct {
 			utils.UserInputReader
-			*api.Client
+			*operations.ProxyLoginOperationClient
 			*config.LocalConfig
 			*utils.CommandRunner
 			*utils.FileOps
 		}{
 			utils.NewStdinInputReader(),
-			api.DefaultClient,
+			&operations.ProxyLoginOperationClient{Client: api.DefaultClient},
 			config.Get(),
 			&utils.CommandRunner{},
 			&utils.FileOps{},

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -29,8 +29,8 @@ func (ssh *SSH) Run(command string) error {
 		"-oUserKnownHostsFile=/dev/null",
 		"-oServerAliveInterval=60",
 		"-oServerAliveCountMax=720", // 12 hours
-		fmt.Sprintf("-oProxyCommand=ssh -W %%h:%%p -i %s hopper@%s", config.PrivateKeyPath, ssh.BastionIP),
-		"-i", config.PrivateKeyPath,
+		fmt.Sprintf("-oProxyCommand=ssh -W %%h:%%p -i %s hopper@%s", config.Get().GetPrivateKeyPath(), ssh.BastionIP),
+		"-i", config.Get().GetPrivateKeyPath(),
 		fmt.Sprintf("ec2-user@%s", ssh.IP),
 		command,
 	}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -15,11 +15,6 @@ func PrintOneoff(o *api.Oneoff) {
 	fmt.Printf("Task ARN: %s\n", o.TaskARN)
 }
 
-func fileExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
-}
-
 type HeritageConfig struct {
 	Environments map[string]*api.Heritage `yaml:"environments" json:"environments"`
 	Review       *api.ReviewAppDefinition `yaml:"review" json:"review"`

--- a/config/config.go
+++ b/config/config.go
@@ -9,8 +9,8 @@ import (
 	homedir "github.com/mitchellh/go-homedir"
 )
 
-var ConfigDir string
-var LoginFilePath string
+var configDir string
+var loginFilePath string
 var privateKeyPath string
 var publicKeyPath string
 var CertPath string
@@ -51,11 +51,11 @@ func init() {
 	if err != nil {
 		panic("Couldn't get login path")
 	}
-	ConfigDir = path
-	LoginFilePath = filepath.Join(ConfigDir, "login")
-	privateKeyPath = filepath.Join(ConfigDir, "id_ecdsa")
-	publicKeyPath = filepath.Join(ConfigDir, "id_ecdsa.pub")
-	CertPath = filepath.Join(ConfigDir, "id_ecdsa-cert.pub")
+	configDir = path
+	loginFilePath = filepath.Join(configDir, "login")
+	privateKeyPath = filepath.Join(configDir, "id_ecdsa")
+	publicKeyPath = filepath.Join(configDir, "id_ecdsa.pub")
+	CertPath = filepath.Join(configDir, "id_ecdsa-cert.pub")
 }
 
 func getConfigPath() (string, error) {
@@ -87,7 +87,7 @@ func (login Login) GetEndpoint() string {
 
 func LoadLogin() *Login {
 	var login Login
-	loginJSON, err := ioutil.ReadFile(LoginFilePath)
+	loginJSON, err := ioutil.ReadFile(loginFilePath)
 	if err != nil {
 		login = Login{}
 	} else {
@@ -112,12 +112,12 @@ func writeLogin(login *Login) error {
 		return err
 	}
 
-	err = os.MkdirAll(ConfigDir, 0775)
+	err = os.MkdirAll(configDir, 0775)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(LoginFilePath, b, 0600)
+	err = ioutil.WriteFile(loginFilePath, b, 0600)
 	if err != nil {
 		return err
 	}

--- a/operations/login_info_operation.go
+++ b/operations/login_info_operation.go
@@ -6,11 +6,20 @@ import (
 	"github.com/degica/barcelona-cli/config"
 )
 
-type LoginInfoOperation struct {
-	cfg config.Configuration
+type LoginInfo interface {
+	GetEndpoint() string
+	GetAuth() string
 }
 
-func NewLoginInfoOperation(cfg config.Configuration) *LoginInfoOperation {
+type LoginConfiguration interface {
+	LoadLogin() *config.Login
+}
+
+type LoginInfoOperation struct {
+	cfg LoginConfiguration
+}
+
+func NewLoginInfoOperation(cfg LoginConfiguration) *LoginInfoOperation {
 	// set only specific field value with field key
 	return &LoginInfoOperation{
 		cfg: cfg,
@@ -20,8 +29,8 @@ func NewLoginInfoOperation(cfg config.Configuration) *LoginInfoOperation {
 func (oper LoginInfoOperation) run() *runResult {
 	login := oper.cfg.LoadLogin()
 
-	fmt.Printf("Endpoint: %s\n", login.Endpoint)
-	fmt.Printf("Auth:     %s\n", login.Auth)
+	fmt.Printf("Endpoint: %s\n", login.GetEndpoint())
+	fmt.Printf("Auth:     %s\n", login.GetAuth())
 
 	return ok_result()
 }

--- a/operations/login_operation.go
+++ b/operations/login_operation.go
@@ -48,7 +48,7 @@ func NewLoginOperation(endpoint string, backend string, gh_token string, vault_t
 		gh_token:    gh_token,
 		vault_token: vault_token,
 		vault_url:   vault_url,
-		ext:      ext,
+		ext:         ext,
 	}
 }
 

--- a/operations/login_operation.go
+++ b/operations/login_operation.go
@@ -20,6 +20,7 @@ type LoginOperationExternals interface {
 	// CommandRunner
 	RunCommand(name string, arg ...string) error
 
+	// Client stufff
 	LoginWithGithub(endpoint string, token string) (*api.User, error)
 	LoginWithVault(endpoint string, vault_url string, token string) (*api.User, error)
 	ReloadDefaultClient() (*api.Client, error)

--- a/operations/login_operation.go
+++ b/operations/login_operation.go
@@ -19,6 +19,7 @@ type LoginOperationExternals interface {
 
 	// CommandRunner
 	RunCommand(name string, arg ...string) error
+	FileExists(path string) bool
 
 	// Client stufff
 	LoginWithGithub(endpoint string, token string) (*api.User, error)
@@ -99,7 +100,7 @@ func vaultLogin(oper LoginOperation, user *api.User) *runResult {
 }
 
 func setUpKeys(oper LoginOperation, user *api.User) *runResult {
-	keyExists := utils.FileExists(oper.ext.GetPublicKeyPath())
+	keyExists := oper.ext.FileExists(oper.ext.GetPublicKeyPath())
 	if !keyExists {
 		fmt.Println("Generating your SSH key pair...")
 		err := oper.ext.RunCommand("ssh-keygen",

--- a/operations/login_operation.go
+++ b/operations/login_operation.go
@@ -26,8 +26,8 @@ func (p ProxyLoginOperationClient) LoginWithGithub(endpoint string, token string
 	return p.Client.LoginWithGithub(endpoint, token)
 }
 
-func (p ProxyLoginOperationClient) LoginWithVault(endpoint string, vault_url string, token string) (*api.User, error) {
-	return p.Client.LoginWithVault(endpoint, vault_url, token)
+func (p ProxyLoginOperationClient) LoginWithVault(vault_url string, token string) (*api.User, error) {
+	return p.Client.LoginWithVault(vault_url, token)
 }
 
 func (p ProxyLoginOperationClient) Patch(path string, body io.Reader) ([]byte, error) {
@@ -36,7 +36,7 @@ func (p ProxyLoginOperationClient) Patch(path string, body io.Reader) ([]byte, e
 
 type LoginOperationClient interface {
 	LoginWithGithub(endpoint string, token string) (*api.User, error)
-	LoginWithVault(endpoint string, vault_url string, token string) (*api.User, error)
+	LoginWithVault(vault_url string, token string) (*api.User, error)
 	Patch(path string, body io.Reader) ([]byte, error)
 }
 
@@ -51,7 +51,7 @@ type LoginOperationExternals interface {
 	FileExists(path string) bool
 	ReadFile(path string) ([]byte, error)
 
-	// Client stufff
+	// Client stuff
 	LoginOperationClient
 	ReloadDefaultClient() (LoginOperationClient, error)
 
@@ -62,28 +62,28 @@ type LoginOperationExternals interface {
 }
 
 type LoginOperation struct {
-	endpoint    string
-	backend     string
-	gh_token    string
-	vault_token string
-	vault_url   string
-	ext         LoginOperationExternals
+	endpoint   string
+	backend    string
+	ghToken    string
+	vaultToken string
+	vaultUrl   string
+	ext        LoginOperationExternals
 }
 
-func NewLoginOperation(endpoint string, backend string, gh_token string, vault_token string, vault_url string, ext LoginOperationExternals) *LoginOperation {
+func NewLoginOperation(endpoint string, backend string, ghToken string, vaultToken string, vaultUrl string, ext LoginOperationExternals) *LoginOperation {
 	return &LoginOperation{
-		endpoint:    endpoint,
-		backend:     backend,
-		gh_token:    gh_token,
-		vault_token: vault_token,
-		vault_url:   vault_url,
-		ext:         ext,
+		endpoint:   endpoint,
+		backend:    backend,
+		ghToken:    ghToken,
+		vaultToken: vaultToken,
+		vaultUrl:   vaultUrl,
+		ext:        ext,
 	}
 }
 
 func githubLogin(oper LoginOperation, user *api.User) *runResult {
 	fmt.Println("Logging in with Github")
-	token := oper.gh_token
+	token := oper.ghToken
 	if len(token) == 0 {
 		fmt.Println("Create new GitHub access token with read:org permission here https://github.com/settings/tokens/new")
 		token = utils.Ask("GitHub Token", true, true, oper.ext)
@@ -104,8 +104,8 @@ func githubLogin(oper LoginOperation, user *api.User) *runResult {
 
 func vaultLogin(oper LoginOperation, user *api.User) *runResult {
 	fmt.Println("Logging in with Vault")
-	token := oper.vault_token
-	url := oper.vault_url
+	token := oper.vaultToken
+	url := oper.vaultUrl
 	if len(token) == 0 {
 		fmt.Println("Create new GitHub access token with read:org permission here https://github.com/settings/tokens/new")
 		token = utils.Ask("GitHub Token", true, true, oper.ext)
@@ -114,11 +114,10 @@ func vaultLogin(oper LoginOperation, user *api.User) *runResult {
 		fmt.Println("URL of vault server (e.g. https://vault.degica.com)")
 		url = utils.Ask("Vault server URL", true, false, oper.ext)
 	}
-	user, err := oper.ext.LoginWithVault(oper.endpoint, url, token)
+	user, err := oper.ext.LoginWithVault(url, token)
 	if err != nil {
 		return error_result(err.Error())
 	}
-
 	err = oper.ext.WriteLogin(oper.backend, user.Token, oper.endpoint)
 	if err != nil {
 		return error_result(err.Error())

--- a/operations/login_operation.go
+++ b/operations/login_operation.go
@@ -19,6 +19,8 @@ type LoginOperationExternals interface {
 
 	// CommandRunner
 	RunCommand(name string, arg ...string) error
+
+	// FileOps
 	FileExists(path string) bool
 
 	// Client stufff

--- a/operations/login_operation.go
+++ b/operations/login_operation.go
@@ -1,0 +1,167 @@
+package operations
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"regexp"
+
+	"encoding/json"
+
+	"github.com/degica/barcelona-cli/api"
+	"github.com/degica/barcelona-cli/utils"
+)
+
+type LoginOperationApiClient interface {
+	LoginWithGithub(endpoint string, token string) (*api.User, error)
+	LoginWithVault(endpoint string, vault_url string, token string) (*api.User, error)
+	ReloadDefaultClient() (*api.Client, error)
+	Patch(path string, body io.Reader) ([]byte, error)
+}
+
+type LoginConfig interface {
+	WriteLogin(auth string, token string, endpoint string) error
+	GetPublicKeyPath() string
+	GetPrivateKeyPath() string
+}
+
+type LoginOperation struct {
+	endpoint    string
+	backend     string
+	gh_token    string
+	vault_token string
+	vault_url   string
+	client      LoginOperationApiClient
+	cfg         LoginConfig
+}
+
+func NewLoginOperation(endpoint string, backend string, gh_token string, vault_token string, vault_url string, client LoginOperationApiClient, cfg LoginConfig) *LoginOperation {
+	return &LoginOperation{
+		endpoint:    endpoint,
+		backend:     backend,
+		gh_token:    gh_token,
+		vault_token: vault_token,
+		vault_url:   vault_url,
+		client:      client,
+		cfg:         cfg,
+	}
+}
+
+func githubLogin(oper LoginOperation, user *api.User) *runResult {
+	fmt.Println("Logging in with Github")
+	token := oper.gh_token
+	if len(token) == 0 {
+		fmt.Println("Create new GitHub access token with read:org permission here https://github.com/settings/tokens/new")
+		token = utils.Ask("GitHub Token", true, true, utils.NewStdinInputReader())
+	}
+
+	user, err := oper.client.LoginWithGithub(oper.endpoint, token)
+	if err != nil {
+		return error_result(err.Error())
+	}
+
+	err = oper.cfg.WriteLogin(oper.backend, user.Token, oper.endpoint)
+	if err != nil {
+		return error_result(err.Error())
+	}
+
+	return ok_result()
+}
+
+func vaultLogin(oper LoginOperation, user *api.User) *runResult {
+	fmt.Println("Logging in with Vault")
+	token := oper.vault_token
+	url := oper.vault_url
+	if len(token) == 0 {
+		fmt.Println("Create new GitHub access token with read:org permission here https://github.com/settings/tokens/new")
+		token = utils.Ask("GitHub Token", true, true, utils.NewStdinInputReader())
+	}
+	if len(url) == 0 {
+		fmt.Println("URL of vault server (e.g. https://vault.degica.com)")
+		url = utils.Ask("Vault server URL", true, false, utils.NewStdinInputReader())
+	}
+	user, err := oper.client.LoginWithVault(oper.endpoint, url, token)
+	if err != nil {
+		return error_result(err.Error())
+	}
+
+	err = oper.cfg.WriteLogin(oper.backend, user.Token, oper.endpoint)
+	if err != nil {
+		return error_result(err.Error())
+	}
+
+	return ok_result()
+}
+
+func setUpKeys(oper LoginOperation, user *api.User) *runResult {
+	keyExists := utils.FileExists(oper.cfg.GetPublicKeyPath())
+	if !keyExists {
+		fmt.Println("Generating your SSH key pair...")
+		cmd := exec.Command("ssh-keygen",
+			"-t", "ecdsa",
+			"-b", "521",
+			"-f", oper.cfg.GetPrivateKeyPath(),
+			"-C", "")
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err := cmd.Run()
+		if err != nil {
+			return error_result(err.Error())
+		}
+	}
+
+	if !keyExists || len(user.PublicKey) == 0 {
+		fmt.Println("Registering your public key...")
+
+		pubKeyB, err := ioutil.ReadFile(oper.cfg.GetPublicKeyPath())
+		if err != nil {
+			return error_result(err.Error())
+		}
+
+		re := regexp.MustCompile(" *\n$")
+		pubKey := re.ReplaceAllString(string(pubKeyB), "")
+		reqBody := make(map[string]string)
+		reqBody["public_key"] = pubKey
+		bodyB, err := json.Marshal(reqBody)
+		oper.client, err = oper.client.ReloadDefaultClient()
+		if err != nil {
+			return error_result(err.Error())
+		}
+
+		_, err = oper.client.Patch("/user", bytes.NewBuffer(bodyB))
+		if err != nil {
+			return error_result(err.Error())
+		}
+	}
+
+	return ok_result()
+}
+
+func (oper LoginOperation) run() *runResult {
+	if len(oper.endpoint) == 0 {
+		return error_result("endpoint is required")
+	}
+
+	var user api.User
+
+	switch oper.backend {
+	case "github":
+		result := githubLogin(oper, &user)
+		if result.is_error {
+			return result
+		}
+	case "vault":
+		result := vaultLogin(oper, &user)
+		if result.is_error {
+			return result
+		}
+	default:
+		return error_result("Unrecognized auth backend")
+	}
+
+	return setUpKeys(oper, &user)
+}

--- a/operations/login_operation.go
+++ b/operations/login_operation.go
@@ -20,7 +20,6 @@ type LoginOperationExternals interface {
 	// CommandRunner
 	RunCommand(name string, arg ...string) error
 
-	// Client stufff
 	LoginWithGithub(endpoint string, token string) (*api.User, error)
 	LoginWithVault(endpoint string, vault_url string, token string) (*api.User, error)
 	ReloadDefaultClient() (*api.Client, error)

--- a/operations/login_operation_test.go
+++ b/operations/login_operation_test.go
@@ -1,0 +1,6 @@
+package operations
+
+import ()
+
+type MockLoginOperationApiClient struct {
+}

--- a/operations/login_operation_test.go
+++ b/operations/login_operation_test.go
@@ -21,6 +21,9 @@ type mockLoginOperationExternals struct {
 	loginWithGithubUser  *api.User
 	loginWithGithubError error
 
+	loginWithVaultUser  *api.User
+	loginWithVaultError error
+
 	readFileBytes []byte
 	readFileError error
 
@@ -51,7 +54,7 @@ func (m mockLoginOperationExternals) LoginWithGithub(endpoint string, token stri
 }
 
 func (m mockLoginOperationExternals) LoginWithVault(endpoint string, vault_url string, token string) (*api.User, error) {
-	return nil, nil
+	return m.loginWithVaultUser, m.loginWithVaultError
 }
 
 func (m mockLoginOperationExternals) ReloadDefaultClient() (LoginOperationClient, error) {
@@ -111,7 +114,7 @@ func ExampleLoginOperation_run_with_github_already_has_ssh() {
 		loginWithGithubUser:  &api.User{},
 		loginWithGithubError: nil,
 		readFileBytes:        []byte("stuff"),
-		fileExistsBool: true,
+		fileExistsBool:       true,
 	}
 
 	op := NewLoginOperation("https://endpoint", "github", "", "", "", ext)
@@ -130,7 +133,7 @@ func ExampleLoginOperation_run_with_github_token_already_has_ssh() {
 		loginWithGithubUser:  &api.User{},
 		loginWithGithubError: nil,
 		readFileBytes:        []byte("stuff"),
-		fileExistsBool: true,
+		fileExistsBool:       true,
 	}
 
 	op := NewLoginOperation("https://endpoint", "github", "gh_token", "", "", ext)
@@ -178,9 +181,178 @@ func ExampleLoginOperation_run_with_github_token() {
 	// Registering your public key...
 }
 
+func TestVaultBackend(t *testing.T) {
+	ext := &mockLoginOperationExternals{
+		readString:          "aw\n",
+		readError:           nil,
+		loginWithVaultUser:  &api.User{},
+		loginWithVaultError: nil,
+		readFileBytes:       []byte("stuff"),
+	}
+
+	op := NewLoginOperation("https://endpoint", "vault", "", "", "", ext)
+	result := op.run()
+
+	if result.is_error != false {
+		t.Errorf("Expected no error to be returned.")
+	}
+}
+
+func ExampleLoginOperation_run_with_vault_already_has_ssh() {
+	ext := &mockLoginOperationExternals{
+		readString:          "aw\n",
+		readError:           nil,
+		loginWithVaultUser:  &api.User{},
+		loginWithVaultError: nil,
+		readFileBytes:       []byte("stuff"),
+		fileExistsBool:      true,
+	}
+
+	op := NewLoginOperation("https://endpoint", "vault", "", "", "", ext)
+	op.run()
+
+	// Output:
+	// Logging in with Vault
+	// Create new GitHub access token with read:org permission here https://github.com/settings/tokens/new
+	// GitHub Token: URL of vault server (e.g. https://vault.degica.com)
+	// Vault server URL: Registering your public key...
+}
+
+func ExampleLoginOperation_run_with_vault_token_already_has_ssh() {
+	ext := &mockLoginOperationExternals{
+		readString:          "aw\n",
+		readError:           nil,
+		loginWithVaultUser:  &api.User{},
+		loginWithVaultError: nil,
+		readFileBytes:       []byte("stuff"),
+		fileExistsBool:      true,
+	}
+
+	op := NewLoginOperation("https://endpoint", "vault", "", "gh_token", "", ext)
+	op.run()
+
+	// Output:
+	// Logging in with Vault
+	// URL of vault server (e.g. https://vault.degica.com)
+	// Vault server URL: Registering your public key...
+}
+
+func ExampleLoginOperation_run_with_vault() {
+	ext := &mockLoginOperationExternals{
+		readString:          "aw\n",
+		readError:           nil,
+		loginWithVaultUser:  &api.User{},
+		loginWithVaultError: nil,
+		readFileBytes:       []byte("stuff"),
+	}
+
+	op := NewLoginOperation("https://endpoint", "vault", "", "", "", ext)
+	op.run()
+
+	// Output:
+	// Logging in with Vault
+	// Create new GitHub access token with read:org permission here https://github.com/settings/tokens/new
+	// GitHub Token: URL of vault server (e.g. https://vault.degica.com)
+	// Vault server URL: Generating your SSH key pair...
+	// Registering your public key...
+}
+
+func ExampleLoginOperation_run_with_vault_token() {
+	ext := &mockLoginOperationExternals{
+		readString:          "aw\n",
+		readError:           nil,
+		loginWithVaultUser:  &api.User{},
+		loginWithVaultError: nil,
+		readFileBytes:       []byte("stuff"),
+	}
+
+	op := NewLoginOperation("https://endpoint", "vault", "", "gh_token", "", ext)
+	op.run()
+
+	// Output:
+	// Logging in with Vault
+	// URL of vault server (e.g. https://vault.degica.com)
+	// Vault server URL: Generating your SSH key pair...
+	// Registering your public key...
+}
+
+func ExampleLoginOperation_run_with_vault_already_has_ssh_given_url() {
+	ext := &mockLoginOperationExternals{
+		readString:          "aw\n",
+		readError:           nil,
+		loginWithVaultUser:  &api.User{},
+		loginWithVaultError: nil,
+		readFileBytes:       []byte("stuff"),
+		fileExistsBool:      true,
+	}
+
+	op := NewLoginOperation("https://endpoint", "vault", "", "", "https://vaultserv", ext)
+	op.run()
+
+	// Output:
+	// Logging in with Vault
+	// Create new GitHub access token with read:org permission here https://github.com/settings/tokens/new
+	// GitHub Token: Registering your public key...
+}
+
+func ExampleLoginOperation_run_with_vault_token_already_has_ssh_given_url() {
+	ext := &mockLoginOperationExternals{
+		readString:          "aw\n",
+		readError:           nil,
+		loginWithVaultUser:  &api.User{},
+		loginWithVaultError: nil,
+		readFileBytes:       []byte("stuff"),
+		fileExistsBool:      true,
+	}
+
+	op := NewLoginOperation("https://endpoint", "vault", "", "gh_token", "https://vaultserv", ext)
+	op.run()
+
+	// Output:
+	// Logging in with Vault
+	// Registering your public key...
+}
+
+func ExampleLoginOperation_run_with_vault_given_url() {
+	ext := &mockLoginOperationExternals{
+		readString:          "aw\n",
+		readError:           nil,
+		loginWithVaultUser:  &api.User{},
+		loginWithVaultError: nil,
+		readFileBytes:       []byte("stuff"),
+	}
+
+	op := NewLoginOperation("https://endpoint", "vault", "", "", "https://vaultserv", ext)
+	op.run()
+
+	// Output:
+	// Logging in with Vault
+	// Create new GitHub access token with read:org permission here https://github.com/settings/tokens/new
+	// GitHub Token: Generating your SSH key pair...
+	// Registering your public key...
+}
+
+func ExampleLoginOperation_run_with_vault_token_given_url() {
+	ext := &mockLoginOperationExternals{
+		readString:          "aw\n",
+		readError:           nil,
+		loginWithVaultUser:  &api.User{},
+		loginWithVaultError: nil,
+		readFileBytes:       []byte("stuff"),
+	}
+
+	op := NewLoginOperation("https://endpoint", "vault", "", "gh_token", "https://vaultserv", ext)
+	op.run()
+
+	// Output:
+	// Logging in with Vault
+	// Generating your SSH key pair...
+	// Registering your public key...
+}
+
 func ExampleLoginOperation_run_output() {
 
-	op := NewLoginOperation("https://endpoint", "mybckend", "gh_token", "vault_token", "https://vault_url", &mockLoginOperationExternals{})
+	op := NewLoginOperation("https://endpoint", "somethingrando", "gh_token", "vault_token", "https://vault_url", &mockLoginOperationExternals{})
 	op.run()
 
 	// Output:

--- a/operations/login_operation_test.go
+++ b/operations/login_operation_test.go
@@ -2,5 +2,15 @@ package operations
 
 import ()
 
-type MockLoginOperationApiClient struct {
+type mockLoginOperationExternals struct {
+}
+
+func ExampleLoginOperationApiClient_run_output() {
+
+	op := NewLoginOperation("https://endpoint", "mybckend", "gh_token", "vault_token", "https://vault_url", &mockLoginOperationExternals{})
+	op.run()
+
+	// Output:
+	// Endpoint: https://test.example.com
+	// Auth:     vault
 }

--- a/operations/login_operation_test.go
+++ b/operations/login_operation_test.go
@@ -350,6 +350,28 @@ func ExampleLoginOperation_run_with_vault_token_given_url() {
 	// Registering your public key...
 }
 
+type mockLoginVaultError struct { }
+
+func (m mockLoginVaultError) Error() string {
+	return "something"
+}
+
+func ExampleLoginOperation_run_with_vault_token_given_url_but_fails() {
+	ext := &mockLoginOperationExternals{
+		readString:          "aw\n",
+		readError:           nil,
+		loginWithVaultUser:  nil,
+		loginWithVaultError: &mockLoginVaultError{},
+		readFileBytes:       []byte("stuff"),
+	}
+
+	op := NewLoginOperation("https://endpoint", "vault", "", "gh_token", "https://vaultserv", ext)
+	op.run()
+
+	// Output:
+	// Logging in with Vault
+}
+
 func ExampleLoginOperation_run_output() {
 
 	op := NewLoginOperation("https://endpoint", "somethingrando", "gh_token", "vault_token", "https://vault_url", &mockLoginOperationExternals{})

--- a/operations/login_operation_test.go
+++ b/operations/login_operation_test.go
@@ -1,8 +1,98 @@
 package operations
 
-import ()
+import (
+	"io"
+	"testing"
+	"github.com/degica/barcelona-cli/api"
+)
+
+type mockLoginOperationError struct {
+	msg string
+}
+
+func (m mockLoginOperationError) Error() string {
+	return m.msg
+}
 
 type mockLoginOperationExternals struct {
+	readString string
+	readError error
+
+	loginWithGithubUser *api.User
+	loginWithGithubError error
+}
+
+func (m mockLoginOperationExternals) Read(secret bool) (string, error) {
+	return m.readString, m.readError
+}
+
+func (m mockLoginOperationExternals) RunCommand(name string, arg ...string) error {
+	return nil
+}
+
+func (m mockLoginOperationExternals) FileExists(path string) bool {
+	return false
+}
+
+func (m mockLoginOperationExternals) LoginWithGithub(endpoint string, token string) (*api.User, error) {
+	return m.loginWithGithubUser, m.loginWithGithubError
+}
+
+func (m mockLoginOperationExternals) LoginWithVault(endpoint string, vault_url string, token string) (*api.User, error) {
+	return nil, nil
+}
+
+func (m mockLoginOperationExternals) ReloadDefaultClient() (*api.Client, error) {
+	return nil, nil
+}
+
+func (m mockLoginOperationExternals) Patch(path string, body io.Reader) ([]byte, error) {
+	return nil, nil
+}
+
+func (m mockLoginOperationExternals) WriteLogin(auth string, token string, endpoint string) error {
+	return nil
+}
+
+func (m mockLoginOperationExternals) GetPublicKeyPath() string {
+	return ""
+}
+
+func (m mockLoginOperationExternals) GetPrivateKeyPath() string {
+	return ""
+}
+
+func TestUnknownBackend(t *testing.T) {
+	op := NewLoginOperation("https://endpoint", "mybckend", "gh_token", "vault_token", "https://vault_url", &mockLoginOperationExternals{})
+	result := op.run()
+
+	if result.is_error != true {
+		t.Errorf("Expected no error to be returned.")
+	}
+
+	if result.message != "Unrecognized auth backend" {
+		t.Errorf("Expected 'Unrecognized auth backend' to be returned.")
+	}
+}
+
+func TestGithubBackend(t *testing.T) {
+	ext := &mockLoginOperationExternals{
+		readString: "aw\n",
+		readError: nil,
+		loginWithGithubUser: &api.User{},
+		loginWithGithubError: nil,
+	}
+
+	op := NewLoginOperation("https://endpoint", "github", "", "", "", ext)
+	result := op.run()
+
+	if result.is_error != true {
+		t.Errorf("Expected no error to be returned.")
+	}
+
+	if result.message != "Unrecognized auth backend" {
+		t.Errorf("Expected 'Unrecognized auth backend' to be returned." + result.message)
+	}
 }
 
 func ExampleLoginOperationApiClient_run_output() {
@@ -11,6 +101,5 @@ func ExampleLoginOperationApiClient_run_output() {
 	op.run()
 
 	// Output:
-	// Endpoint: https://test.example.com
-	// Auth:     vault
+	// 
 }

--- a/operations/login_operation_test.go
+++ b/operations/login_operation_test.go
@@ -53,7 +53,7 @@ func (m mockLoginOperationExternals) LoginWithGithub(endpoint string, token stri
 	return m.loginWithGithubUser, m.loginWithGithubError
 }
 
-func (m mockLoginOperationExternals) LoginWithVault(endpoint string, vault_url string, token string) (*api.User, error) {
+func (m mockLoginOperationExternals) LoginWithVault(vault_url string, token string) (*api.User, error) {
 	return m.loginWithVaultUser, m.loginWithVaultError
 }
 
@@ -350,7 +350,7 @@ func ExampleLoginOperation_run_with_vault_token_given_url() {
 	// Registering your public key...
 }
 
-type mockLoginVaultError struct { }
+type mockLoginVaultError struct{}
 
 func (m mockLoginVaultError) Error() string {
 	return "something"

--- a/utils/command_runner.go
+++ b/utils/command_runner.go
@@ -1,0 +1,17 @@
+package utils
+
+import (
+	"os"
+	"os/exec"
+)
+
+type CommandRunner struct {
+}
+
+func (cr CommandRunner) RunCommand(name string, arg ...string) error {
+	cmd := exec.Command(name, arg...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/utils/file_exists.go
+++ b/utils/file_exists.go
@@ -1,0 +1,10 @@
+package utils
+
+import (
+	"os"
+)
+
+func FileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/utils/file_ops.go
+++ b/utils/file_ops.go
@@ -4,7 +4,10 @@ import (
 	"os"
 )
 
-func FileExists(path string) bool {
+type FileOps struct {
+}
+
+func (_ FileOps) FileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
 }

--- a/utils/file_ops.go
+++ b/utils/file_ops.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"io/ioutil"
 	"os"
 )
 
@@ -10,4 +11,8 @@ type FileOps struct {
 func (_ FileOps) FileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+func (_ FileOps) ReadFile(path string) ([]byte, error) {
+	return ioutil.ReadFile(path)
 }


### PR DESCRIPTION
## Context

This PR introduces a mechanism to login to vault. This PR has a large number of line changes, which are mostly tests (login was not tested before) and mocks to facilitate testing. If you find this PR too long, I can split it up a little more into possibly a refactor PR and test PR.

## How to test
> Since this is a client, you don't need to have a bcn account, simply knowing that it sends the right requests is sufficient, though you are welcome to `kaiser up` barcelona on your local machine and following [these instructions](https://github.com/degica/barcelona/pull/605) if you wish to see everything working.
1. Simply attempt to login to vault by going: `bcn -d login https://example.com --auth vault`
2. You should be prompted to enter a github token and vault server url, just enter some random value. It doesn't matter. You can use "https://example.com" to test past any errors you may encounter if you use an invalid URL.
3. You should see the following result
```
Logging in with Vault
Create new GitHub access token with read:org permission here https://github.com/settings/tokens/new
GitHub Token: URL of vault server (e.g. https://vault.degica.com)
Vault server URL: https://example.com
POST /v1/auth/github/login?debug=true HTTP/1.1
Host: example.com
User-Agent: Go-http-client/1.1
Content-Length: 20
Accept: application/json
Content-Type: application/json
Accept-Encoding: gzip

{"token":"adasdasd"}
HTTP/2.0 404 Not Found
... and other errors
```
4. But observe that it says `logging in with Vault` and sends the token you provided to the vault server.