### PR TITLE
Refactor Config

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -44,20 +44,14 @@ func NewClient(c *Config, l *config.Login) *Client {
 	return &Client{login: l, config: c}
 }
 
-func newDefaultClient() (*Client, error) {
+func newDefaultClient() *Client {
 	c := DefaultConfig()
-	l := config.LoadLogin()
-	cli := NewClient(c, l)
-
-	return cli, nil
+	l := config.Get().LoadLogin()
+	return NewClient(c, l)
 }
 
 func reloadDefaultClient() error {
-	cli, err := newDefaultClient()
-	if err != nil {
-		return err
-	}
-	DefaultClient = cli
+	DefaultClient = newDefaultClient()
 	return nil
 }
 
@@ -65,7 +59,7 @@ func (cli *Client) rawRequest(req *http.Request) ([]byte, error) {
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")
 
-	if config.Debug {
+	if config.Get().IsDebug() {
 		q := req.URL.Query()
 		q.Add("debug", "true")
 		req.URL.RawQuery = q.Encode()
@@ -78,7 +72,7 @@ func (cli *Client) rawRequest(req *http.Request) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	if config.Debug {
+	if config.Get().IsDebug() {
 		//Is dumping response too much? Probably not.
 		dump(httputil.DumpResponse(resp, true))
 	}

--- a/api/types.go
+++ b/api/types.go
@@ -310,7 +310,7 @@ type VaultAuthResponse struct {
 }
 
 func (err *APIError) Error() string {
-	if config.Debug {
+	if config.Get().IsDebug() {
 		return fmt.Sprintf("%s\n\n%s\n%s\n", err.Message, err.DebugMessage, strings.Join(err.Backtrace, "\n"))
 	} else {
 		return err.Message

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -60,7 +60,7 @@ var LoginCommand = cli.Command{
 			Name:  "info",
 			Usage: "Show login information",
 			Action: func(c *cli.Context) error {
-				operation := operations.NewLoginInfoOperation(config.Get())
+				operation := operations.NewLoginInfoOperation(config.Get().LoadLogin())
 				return operations.Execute(operation)
 			},
 		},

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -17,7 +17,7 @@ type SSH struct {
 }
 
 func (ssh *SSH) Run(command string) error {
-	err := ioutil.WriteFile(config.CertPath, []byte(ssh.Certificate), 0644)
+	err := ioutil.WriteFile(config.Get().GetCertPath(), []byte(ssh.Certificate), 0644)
 	if err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -75,33 +75,6 @@ func (m LocalConfig) WriteLogin(auth string, token string, endpoint string) erro
 	return nil
 }
 
-func getConfigPath() (string, error) {
-	homedir, err := homedir.Dir()
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(homedir, ".bcn"), nil
-}
-
-type Login struct {
-	Auth     string `json:"auth"`
-	Token    string `json:"token"`
-	Endpoint string `json:"endpoint"`
-}
-
-func (login Login) GetAuth() string {
-	return login.Auth
-}
-
-func (login Login) GetToken() string {
-	return login.Token
-}
-
-func (login Login) GetEndpoint() string {
-	return login.Endpoint
-}
-
 func (m LocalConfig) LoadLogin() *Login {
 	var login Login
 	loginJSON, err := ioutil.ReadFile(m.loginFilePath)
@@ -121,4 +94,13 @@ func (m LocalConfig) LoadLogin() *Login {
 	}
 
 	return &login
+}
+
+func getConfigPath() (string, error) {
+	homedir, err := homedir.Dir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(homedir, ".bcn"), nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -53,9 +53,9 @@ func (m LocalConfig) IsDebug() bool {
 
 func (m LocalConfig) WriteLogin(auth string, token string, endpoint string) error {
 	login := &Login{
-		auth:     auth,
-		token:    token,
-		endpoint: endpoint,
+		Auth:     auth,
+		Token:    token,
+		Endpoint: endpoint,
 	}
 
 	b, err := json.Marshal(login)
@@ -90,7 +90,7 @@ func (m LocalConfig) LoadLogin() *Login {
 	// Overwrite endpoint with env var if exists
 	ep := os.Getenv("BARCELONA_ENDPOINT")
 	if len(ep) > 0 {
-		login.endpoint = ep
+		login.Endpoint = ep
 	}
 
 	return &login

--- a/config/config.go
+++ b/config/config.go
@@ -18,21 +18,21 @@ func Get() *LocalConfig {
 		panic("Couldn't get login path")
 	}
 	return &LocalConfig{
-		configDir: path,
-		loginFilePath: filepath.Join(path, "login"),
+		configDir:      path,
+		loginFilePath:  filepath.Join(path, "login"),
 		privateKeyPath: filepath.Join(path, "id_ecdsa"),
-		publicKeyPath: filepath.Join(path, "id_ecdsa.pub"),
-		certPath: filepath.Join(path, "id_ecdsa-cert.pub"),
+		publicKeyPath:  filepath.Join(path, "id_ecdsa.pub"),
+		certPath:       filepath.Join(path, "id_ecdsa-cert.pub"),
 	}
 }
 
 // Implementation of our Configuration object
-type LocalConfig struct{
-	configDir string
-	loginFilePath string
+type LocalConfig struct {
+	configDir      string
+	loginFilePath  string
 	privateKeyPath string
-	publicKeyPath string
-	certPath string
+	publicKeyPath  string
+	certPath       string
 }
 
 func (m LocalConfig) GetPrivateKeyPath() string {

--- a/config/config.go
+++ b/config/config.go
@@ -53,9 +53,9 @@ func (m LocalConfig) IsDebug() bool {
 
 func (m LocalConfig) WriteLogin(auth string, token string, endpoint string) error {
 	login := &Login{
-		Auth:     auth,
-		Token:    token,
-		Endpoint: endpoint,
+		auth:     auth,
+		token:    token,
+		endpoint: endpoint,
 	}
 
 	b, err := json.Marshal(login)
@@ -90,7 +90,7 @@ func (m LocalConfig) LoadLogin() *Login {
 	// Overwrite endpoint with env var if exists
 	ep := os.Getenv("BARCELONA_ENDPOINT")
 	if len(ep) > 0 {
-		login.Endpoint = ep
+		login.endpoint = ep
 	}
 
 	return &login

--- a/config/login.go
+++ b/config/login.go
@@ -1,0 +1,21 @@
+package config
+
+import ()
+
+type Login struct {
+	auth     string `json:"auth"`
+	token    string `json:"token"`
+	endpoint string `json:"endpoint"`
+}
+
+func (login Login) GetAuth() string {
+	return login.auth
+}
+
+func (login Login) GetToken() string {
+	return login.token
+}
+
+func (login Login) GetEndpoint() string {
+	return login.endpoint
+}

--- a/config/login.go
+++ b/config/login.go
@@ -3,19 +3,19 @@ package config
 import ()
 
 type Login struct {
-	auth     string `json:"auth"`
-	token    string `json:"token"`
-	endpoint string `json:"endpoint"`
+	Auth     string `json:"auth"`
+	Token    string `json:"token"`
+	Endpoint string `json:"endpoint"`
 }
 
 func (login Login) GetAuth() string {
-	return login.auth
+	return login.Auth
 }
 
 func (login Login) GetToken() string {
-	return login.token
+	return login.Token
 }
 
 func (login Login) GetEndpoint() string {
-	return login.endpoint
+	return login.Endpoint
 }

--- a/operations/login_info_operation.go
+++ b/operations/login_info_operation.go
@@ -2,8 +2,6 @@ package operations
 
 import (
 	"fmt"
-
-	"github.com/degica/barcelona-cli/config"
 )
 
 type LoginInfo interface {
@@ -11,26 +9,20 @@ type LoginInfo interface {
 	GetAuth() string
 }
 
-type LoginConfiguration interface {
-	LoadLogin() *config.Login
-}
-
 type LoginInfoOperation struct {
-	cfg LoginConfiguration
+	info LoginInfo
 }
 
-func NewLoginInfoOperation(cfg LoginConfiguration) *LoginInfoOperation {
+func NewLoginInfoOperation(info LoginInfo) *LoginInfoOperation {
 	// set only specific field value with field key
 	return &LoginInfoOperation{
-		cfg: cfg,
+		info: info,
 	}
 }
 
 func (oper LoginInfoOperation) run() *runResult {
-	login := oper.cfg.LoadLogin()
-
-	fmt.Printf("Endpoint: %s\n", login.GetEndpoint())
-	fmt.Printf("Auth:     %s\n", login.GetAuth())
+	fmt.Printf("Endpoint: %s\n", oper.info.GetEndpoint())
+	fmt.Printf("Auth:     %s\n", oper.info.GetAuth())
 
 	return ok_result()
 }

--- a/operations/login_info_operation_test.go
+++ b/operations/login_info_operation_test.go
@@ -1,24 +1,23 @@
 package operations
 
-import (
-	"github.com/degica/barcelona-cli/config"
-)
+import ()
 
-type mockConfig struct{}
+type mockLogin struct{}
 
-func (m mockConfig) LoadLogin() *config.Login {
-	return &config.Login{
-		Auth:     "vault",
-		Endpoint: "https://test.example.com",
-	}
+func (m mockLogin) GetAuth() string {
+	return "fooauth"
+}
+
+func (m mockLogin) GetEndpoint() string {
+	return "https://example.com"
 }
 
 func ExampleLoginInfoOperation_run_output() {
 
-	op := NewLoginInfoOperation(&mockConfig{})
+	op := NewLoginInfoOperation(&mockLogin{})
 	op.run()
 
 	// Output:
-	// Endpoint: https://test.example.com
-	// Auth:     vault
+	// Endpoint: https://example.com
+	// Auth:     fooauth
 }


### PR DESCRIPTION
Refactor Tuesday presents another bunch of refactoring! Today we refactor the Config package to not use an ugly package init, since it no longer needs it and supplies a proper type with which to read configuration.

This PR moves config into its own object and privates the variables which are readonly anyway