### PR TITLE
Profiles

### DIFF
--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -46,7 +46,6 @@ var ProfileCommand = cli.Command{
 	Usage: "Manage profiles",
 	Subcommands: profileSubcommands([]string{
 		"create",
-		"delete",
 		"use",
 		"show",
 	}),

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -23,10 +23,12 @@ func profileSubcommands(opnames []string) []cli.Command {
 				ext := struct {
 					utils.UserInputReader
 					*config.LocalConfig
+					*config.Login
 					*utils.FileOps
 				}{
 					utils.NewStdinInputReader(),
 					config.Get(),
+					config.Get().LoadLogin(),
 					&utils.FileOps{},
 				}
 

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -1,22 +1,22 @@
 package cmd
 
 import (
-	"strings"
 	"github.com/degica/barcelona-cli/config"
 	"github.com/degica/barcelona-cli/operations"
 	"github.com/degica/barcelona-cli/utils"
 	"github.com/urfave/cli"
+	"strings"
 )
 
 func profileSubcommands(opnames []string) []cli.Command {
 	var array []cli.Command
 
-  for _, opname := range opnames {
-  	subcommand := cli.Command{
+	for _, opname := range opnames {
+		subcommand := cli.Command{
 			Name:      opname,
 			Usage:     strings.Title(opname) + " a profile",
 			ArgsUsage: "PROFILE_NAME",
-			Flags: []cli.Flag{},
+			Flags:     []cli.Flag{},
 			Action: func(c *cli.Context) error {
 				name := c.Args().Get(0)
 
@@ -35,9 +35,9 @@ func profileSubcommands(opnames []string) []cli.Command {
 				oper := operations.NewProfileOperation(c.Command.Name, name, ext)
 				return operations.Execute(oper)
 			},
-  	}
-    array = append(array, subcommand)
-  }
+		}
+		array = append(array, subcommand)
+	}
 	return array
 }
 

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"strings"
+	"github.com/degica/barcelona-cli/config"
 	"github.com/degica/barcelona-cli/operations"
+	"github.com/degica/barcelona-cli/utils"
 	"github.com/urfave/cli"
 )
 
@@ -18,7 +20,17 @@ func profileSubcommands(opnames []string) []cli.Command {
 			Action: func(c *cli.Context) error {
 				name := c.Args().Get(0)
 
-				oper := operations.NewProfileOperation(c.Command.Name, name)
+				ext := struct {
+					utils.UserInputReader
+					*config.LocalConfig
+					*utils.FileOps
+				}{
+					utils.NewStdinInputReader(),
+					config.Get(),
+					&utils.FileOps{},
+				}
+
+				oper := operations.NewProfileOperation(c.Command.Name, name, ext)
 				return operations.Execute(oper)
 			},
   	}

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"strings"
+	"github.com/degica/barcelona-cli/operations"
+	"github.com/urfave/cli"
+)
+
+func profileSubcommands(opnames []string) []cli.Command {
+	var array []cli.Command
+
+  for _, opname := range opnames {
+  	subcommand := cli.Command{
+			Name:      opname,
+			Usage:     strings.Title(opname) + " a profile",
+			ArgsUsage: "PROFILE_NAME",
+			Flags: []cli.Flag{},
+			Action: func(c *cli.Context) error {
+				name := c.Args().Get(0)
+
+				oper := operations.NewProfileOperation(c.Command.Name, name)
+				return operations.Execute(oper)
+			},
+  	}
+    array = append(array, subcommand)
+  }
+	return array
+}
+
+var ProfileCommand = cli.Command{
+	Name:  "profile",
+	Usage: "Manage profiles",
+	Subcommands: profileSubcommands([]string{
+		"create",
+		"delete",
+		"use",
+		"show",
+	}),
+}

--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,10 @@ func (m LocalConfig) GetCertPath() string {
 	return m.certPath
 }
 
+func (m LocalConfig) GetConfigDir() string {
+	return m.configDir
+}
+
 func (m LocalConfig) IsDebug() bool {
 	return Debug
 }

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func main() {
 		cmd.NotificationCommand,
 		cmd.AppCommand,
 		cmd.ReviewCommand,
+		cmd.ProfileCommand,
 	}
 
 	app.Run(os.Args)

--- a/operations/profile_file.go
+++ b/operations/profile_file.go
@@ -4,10 +4,10 @@ import (
 	"github.com/degica/barcelona-cli/config"
 )
 
-type ProfileFile struct {
-	name       string       `json:"name"`
-	login      config.Login `json:"login"`
-	privateKey string       `json:"privateKey"`
-	publicKey  string       `json:"publicKey"`
-	cert       string       `json:"cert"`
+type profileFile struct {
+	Name       string       `json:"name"`
+	Login      config.Login `json:"login"`
+	PrivateKey string       `json:"privateKey"`
+	PublicKey  string       `json:"publicKey"`
+	Cert       string       `json:"cert"`
 }

--- a/operations/profile_file.go
+++ b/operations/profile_file.go
@@ -1,0 +1,13 @@
+package operations
+
+import (
+	"github.com/degica/barcelona-cli/config"
+)
+
+type ProfileFile struct {
+	name       string       `json:"name"`
+	login      config.Login `json:"login"`
+	privateKey string       `json:"privateKey"`
+	publicKey  string       `json:"publicKey"`
+	cert       string       `json:"cert"`
+}

--- a/operations/profile_operation.go
+++ b/operations/profile_operation.go
@@ -206,7 +206,7 @@ func (oper ProfileOperation) getProfile() (*profileFile, error) {
 
 	certBytes, err3 := oper.file_ops.ReadFile(oper.file_ops.GetCertPath())
 	if err3 != nil {
-		return nil, err3
+		certBytes = []byte{}
 	}
 
 	pfile.PrivateKey = string(privateKeyBytes)

--- a/operations/profile_operation.go
+++ b/operations/profile_operation.go
@@ -1,60 +1,159 @@
 package operations
 
 import (
+	"encoding/json"
 	"fmt"
+	"path/filepath"
 )
 
-type ProfileOperation struct {
-	opname string
-	name string
+type ProfileFileOps interface {
+	FileExists(path string) bool
+	ReadFile(path string) ([]byte, error)
+	WriteFile(path string, contents []byte) error
+	GetConfigDir() string
+	GetLoginEndpoint() string
 }
 
-func NewProfileOperation(opname string, name string) *ProfileOperation {
+type ProfileOperation struct {
+	opname               string
+	name                 string
+	file_ops             ProfileFileOps
+	current_profile_file string
+}
+
+
+func NewProfileOperation(opname string, name string, file_ops ProfileFileOps) *ProfileOperation {
 	return &ProfileOperation{
-		opname: opname,
-		name: name,
+		opname:               opname,
+		name:                 name,
+		file_ops:             file_ops,
+		current_profile_file: filepath.Join(file_ops.GetConfigDir(), "current_profile"),
 	}
 }
 
 func (oper ProfileOperation) run() *runResult {
 	switch oper.opname {
 	case "create":
-		return createProfile(oper.name)
+		return oper.createProfile()
 	case "delete":
-		return deleteProfile(oper.name)
+		return oper.deleteProfile()
 	case "use":
-		return useProfile(oper.name)
+		return oper.useProfile()
 	case "show":
-		return showProfile(oper.name)
+		return oper.showProfile()
 	}
 	return error_result("Unknown command")
 }
 
-func createProfile(name string) *runResult {
-	if name == "" {
+func (oper ProfileOperation) createProfile() *runResult {
+	if oper.name == "" {
 		return error_result("Please enter a name")
 	}
-	
+
 	return ok_result()
 }
 
-func deleteProfile(name string) *runResult {
-	if name == "" {
-		return error_result("Please enter a name")
-	}
-	return ok_result()
-}
-
-func useProfile(name string) *runResult {
-	if name == "" {
+func (oper ProfileOperation) deleteProfile() *runResult {
+	if oper.name == "" {
 		return error_result("Please enter a name")
 	}
 	return ok_result()
 }
 
-func showProfile(name string) *runResult {
-	if name == "" {
-		fmt.Println("Current profile: default")
+func (oper ProfileOperation) useProfile() *runResult {
+	if oper.name == "" {
+		return error_result("Please enter a name")
 	}
 	return ok_result()
+}
+
+func (oper ProfileOperation) showProfile() *runResult {
+	var profile_name = "default"
+	var url = oper.file_ops.GetLoginEndpoint()
+
+	if oper.name == "" {
+		if oper.file_ops.FileExists(oper.current_profile_file) {
+			contents, err := oper.file_ops.ReadFile(oper.current_profile_file)
+			if err != nil {
+				return error_result(err.Error())
+			}
+
+			profile_name = string(contents)
+		}
+	} else {
+		profile_file := filepath.Join(oper.file_ops.GetConfigDir(), "profile_"+oper.name)
+		if oper.file_ops.FileExists(profile_file) {
+
+			var profile ProfileFile
+			profileJson, err := oper.file_ops.ReadFile(profile_file)
+			if err != nil {
+				return error_result(err.Error())
+			}
+		
+			err = json.Unmarshal(profileJson, &profile)
+			if err != nil {
+				return error_result(err.Error())
+			}
+
+			profile_name = profile.name
+			url = profile.login.Endpoint
+
+		} else {
+			return error_result("Profile does not exist")
+		}
+	}
+
+	fmt.Println("Profile:", profile_name)
+	fmt.Println("URL:", url)
+
+	return ok_result()
+}
+
+type profileError struct {
+	error string
+}
+
+func (err profileError) Error() string {
+	return err.error
+}
+
+func (oper ProfileOperation) profilePath(name string) string {
+	return filepath.Join(oper.file_ops.GetConfigDir(), "profile_" + name)
+}
+
+func (oper ProfileOperation) profileExists(name string) bool {
+	return oper.file_ops.FileExists(oper.profilePath(name))
+}
+
+func (oper ProfileOperation) loadProfile(name string) (*ProfileFile, error) {
+	if (!oper.profileExists(name)) {
+		return nil, &profileError{error: "profile " + name + " does not exist"}
+	}
+
+	profilePath := oper.profilePath(name)
+	var pfile ProfileFile
+	profileJson, err := oper.file_ops.ReadFile(profilePath)
+	if err != nil {
+		return nil, err
+	} else {
+		err = json.Unmarshal(profileJson, &pfile)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &pfile, nil
+}
+
+func (oper ProfileOperation) saveProfile(name string, profile *ProfileFile) (error) {
+	b, err := json.Marshal(profile)
+	if err != nil {
+		return err
+	}
+
+	err = oper.file_ops.WriteFile(oper.profilePath(name), b)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/operations/profile_operation.go
+++ b/operations/profile_operation.go
@@ -86,9 +86,9 @@ func createProfile(oper profileManipulationInterface, name string) *runResult {
 		return error_result(err.Error())
 	}
 
-	profile, err := oper.getProfile()
-	if err != nil {
-		return error_result(err.Error())
+	profile, err2 := oper.getProfile()
+	if err2 != nil {
+		return error_result(err2.Error())
 	}
 
 	profile.Name = curr_name
@@ -97,9 +97,9 @@ func createProfile(oper profileManipulationInterface, name string) *runResult {
 		return error_result(saveError.Error())
 	}
 
-	newProfile, err := oper.getProfile()
-	if err != nil {
-		return error_result(err.Error())
+	newProfile, err3 := oper.getProfile()
+	if err3 != nil {
+		return error_result(err3.Error())
 	}
 
 	newProfile.Name = name
@@ -165,7 +165,7 @@ func initializeProfiles(oper profileManipulationInterface) error {
 
 	profile, err := oper.getProfile()
 	if err != nil {
-		profile = &profileFile{}
+		return err
 	}
 
 	profile.Name = "default"
@@ -194,19 +194,19 @@ func (oper ProfileOperation) getProfile() (*profileFile, error) {
 	pfile.Login.Token = oper.file_ops.GetToken()
 	pfile.Login.Endpoint = oper.file_ops.GetEndpoint()
 
-	privateKeyBytes, err := oper.file_ops.ReadFile(oper.file_ops.GetPrivateKeyPath())
-	if err != nil {
-		return nil, err
+	privateKeyBytes, err1 := oper.file_ops.ReadFile(oper.file_ops.GetPrivateKeyPath())
+	if err1 != nil {
+		return nil, err1
 	}
 
-	publicKeyBytes, err := oper.file_ops.ReadFile(oper.file_ops.GetPublicKeyPath())
-	if err != nil {
-		return nil, err
+	publicKeyBytes, err2 := oper.file_ops.ReadFile(oper.file_ops.GetPublicKeyPath())
+	if err2 != nil {
+		return nil, err2
 	}
 
-	certBytes, err := oper.file_ops.ReadFile(oper.file_ops.GetCertPath())
-	if err != nil {
-		return nil, err
+	certBytes, err3 := oper.file_ops.ReadFile(oper.file_ops.GetCertPath())
+	if err3 != nil {
+		return nil, err3
 	}
 
 	pfile.PrivateKey = string(privateKeyBytes)

--- a/operations/profile_operation.go
+++ b/operations/profile_operation.go
@@ -61,7 +61,7 @@ func (oper ProfileOperation) run() *runResult {
 	ops := struct {
 		ProfileOperation
 		ProfileFileOps
-	}{ oper, oper.file_ops }
+	}{oper, oper.file_ops}
 
 	initializeProfiles(ops)
 
@@ -82,17 +82,25 @@ func createProfile(oper profileManipulationInterface, name string) *runResult {
 	}
 
 	curr_name, err := oper.currentProfileName()
-	if err != nil { return error_result(err.Error()) }
+	if err != nil {
+		return error_result(err.Error())
+	}
 
 	profile, err := oper.getProfile()
-	if err != nil { return error_result(err.Error()) }
+	if err != nil {
+		return error_result(err.Error())
+	}
 
 	profile.Name = curr_name
 	saveError := oper.saveProfile(curr_name, profile)
-	if saveError != nil { return error_result(saveError.Error()) }
+	if saveError != nil {
+		return error_result(saveError.Error())
+	}
 
 	newProfile, err := oper.getProfile()
-	if err != nil { return error_result(err.Error()) }
+	if err != nil {
+		return error_result(err.Error())
+	}
 
 	newProfile.Name = name
 	oper.setProfile(*newProfile)
@@ -106,14 +114,20 @@ func useProfile(oper profileManipulationInterface, name string) *runResult {
 	}
 
 	curr_name, err := oper.currentProfileName()
-	if err != nil { return error_result(err.Error()) }
+	if err != nil {
+		return error_result(err.Error())
+	}
 
 	profile, err := oper.getProfile()
-	if err != nil { return error_result(err.Error()) }
+	if err != nil {
+		return error_result(err.Error())
+	}
 
 	profile.Name = curr_name
 	saveError := oper.saveProfile(curr_name, profile)
-	if saveError != nil { return error_result(saveError.Error()) }
+	if saveError != nil {
+		return error_result(saveError.Error())
+	}
 
 	loadedProfile, err := oper.loadProfile(name)
 	if err != nil {
@@ -156,7 +170,9 @@ func initializeProfiles(oper profileManipulationInterface) error {
 
 	profile.Name = "default"
 	err1 := oper.setProfile(*profile)
-	if err1 != nil { return err1 }
+	if err1 != nil {
+		return err1
+	}
 
 	return nil
 }
@@ -169,7 +185,9 @@ func (oper ProfileOperation) getProfile() (*profileFile, error) {
 	var pfile profileFile
 
 	name, err := oper.currentProfileName()
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 
 	pfile.Name = name
 	pfile.Login.Auth = oper.file_ops.GetAuth()
@@ -177,13 +195,19 @@ func (oper ProfileOperation) getProfile() (*profileFile, error) {
 	pfile.Login.Endpoint = oper.file_ops.GetEndpoint()
 
 	privateKeyBytes, err := oper.file_ops.ReadFile(oper.file_ops.GetPrivateKeyPath())
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 
 	publicKeyBytes, err := oper.file_ops.ReadFile(oper.file_ops.GetPublicKeyPath())
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 
 	certBytes, err := oper.file_ops.ReadFile(oper.file_ops.GetCertPath())
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 
 	pfile.PrivateKey = string(privateKeyBytes)
 	pfile.PublicKey = string(publicKeyBytes)
@@ -194,19 +218,29 @@ func (oper ProfileOperation) getProfile() (*profileFile, error) {
 
 func (oper ProfileOperation) setProfile(profile profileFile) error {
 	err := oper.file_ops.WriteFile(oper.current_profile_file, []byte(profile.Name))
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 
 	err1 := oper.file_ops.WriteLogin(profile.Login.Auth, profile.Login.Token, profile.Login.Endpoint)
-	if err1 != nil { return err1 }
+	if err1 != nil {
+		return err1
+	}
 
 	err2 := oper.file_ops.WriteFile(oper.file_ops.GetPrivateKeyPath(), []byte(profile.PrivateKey))
-	if err2 != nil { return err2 }
+	if err2 != nil {
+		return err2
+	}
 
 	err3 := oper.file_ops.WriteFile(oper.file_ops.GetPublicKeyPath(), []byte(profile.PublicKey))
-	if err3 != nil { return err3 }
+	if err3 != nil {
+		return err3
+	}
 
 	err4 := oper.file_ops.WriteFile(oper.file_ops.GetCertPath(), []byte(profile.Cert))
-	if err4 != nil { return err4 }
+	if err4 != nil {
+		return err4
+	}
 
 	return nil
 }
@@ -225,7 +259,7 @@ func (oper ProfileOperation) currentProfileName() (string, error) {
 }
 
 func (oper ProfileOperation) profilePath(name string) string {
-	return filepath.Join(oper.file_ops.GetConfigDir(), "profile_" + name)
+	return filepath.Join(oper.file_ops.GetConfigDir(), "profile_"+name)
 }
 
 func (oper ProfileOperation) profileExists(name string) bool {

--- a/operations/profile_operation.go
+++ b/operations/profile_operation.go
@@ -1,0 +1,60 @@
+package operations
+
+import (
+	"fmt"
+)
+
+type ProfileOperation struct {
+	opname string
+	name string
+}
+
+func NewProfileOperation(opname string, name string) *ProfileOperation {
+	return &ProfileOperation{
+		opname: opname,
+		name: name,
+	}
+}
+
+func (oper ProfileOperation) run() *runResult {
+	switch oper.opname {
+	case "create":
+		return createProfile(oper.name)
+	case "delete":
+		return deleteProfile(oper.name)
+	case "use":
+		return useProfile(oper.name)
+	case "show":
+		return showProfile(oper.name)
+	}
+	return error_result("Unknown command")
+}
+
+func createProfile(name string) *runResult {
+	if name == "" {
+		return error_result("Please enter a name")
+	}
+	
+	return ok_result()
+}
+
+func deleteProfile(name string) *runResult {
+	if name == "" {
+		return error_result("Please enter a name")
+	}
+	return ok_result()
+}
+
+func useProfile(name string) *runResult {
+	if name == "" {
+		return error_result("Please enter a name")
+	}
+	return ok_result()
+}
+
+func showProfile(name string) *runResult {
+	if name == "" {
+		fmt.Println("Current profile: default")
+	}
+	return ok_result()
+}

--- a/operations/profile_operation_test.go
+++ b/operations/profile_operation_test.go
@@ -1,8 +1,8 @@
 package operations
 
 import (
-	"testing"
 	"github.com/degica/barcelona-cli/config"
+	"testing"
 )
 
 type MockProfileFileOps struct {
@@ -90,11 +90,11 @@ func (_ MockProfileManipulation) GetEndpoint() string {
 // ========================================================
 // TestCreateProfile
 // ========================================================
-// 
+//
 
 type MockProfileManipulationForCreateProfile struct {
 	MockProfileManipulation
-	profiles map[string]*profileFile
+	profiles   map[string]*profileFile
 	curprofile string
 }
 
@@ -118,7 +118,7 @@ func (m *MockProfileManipulationForCreateProfile) setProfile(pfile profileFile) 
 
 func TestCreateProfile(t *testing.T) {
 	oper := &MockProfileManipulationForCreateProfile{
-		profiles: map[string]*profileFile{},
+		profiles:   map[string]*profileFile{},
 		curprofile: "adefault",
 	}
 
@@ -144,10 +144,10 @@ func TestCreateProfile(t *testing.T) {
 
 type MockProfileManipulationForUseProfile struct {
 	MockProfileManipulation
-	curprofile string
-	savedProfile string
-	loadedProfile string
-	currentProfile *profileFile
+	curprofile       string
+	savedProfile     string
+	loadedProfile    string
+	currentProfile   *profileFile
 	loadProfileError error
 }
 
@@ -203,7 +203,7 @@ func TestUseProfile(t *testing.T) {
 
 func TestUseNonexistentProfile(t *testing.T) {
 	oper := &MockProfileManipulationForUseProfile{
-		curprofile: "p1",
+		curprofile:       "p1",
 		loadProfileError: profileError{},
 	}
 
@@ -223,7 +223,7 @@ type MockProfileManipulationForShowProfile struct {
 	MockProfileManipulation
 
 	loadProfileResult *profileFile
-	loadProfileError error
+	loadProfileError  error
 }
 
 func (_ MockProfileManipulationForShowProfile) GetEndpoint() string {
@@ -250,7 +250,7 @@ func Example_showProfile_with_no_param() {
 }
 
 func Example_showProfile_with_specified_profile() {
-	
+
 	oper := MockProfileManipulationForShowProfile{
 		loadProfileResult: &profileFile{
 			Name: "aspecificprofile",
@@ -308,13 +308,13 @@ type MockProfileOperationForTestInitializeProfile struct {
 	MockProfileManipulation
 
 	getProfileOutput profileFile
-	getProfileError error
+	getProfileError  error
 
 	profileThatWasSet *profileFile
-	setProfileError error
+	setProfileError   error
 
 	currentProfileNameString string
-	currentProfileNameError error
+	currentProfileNameError  error
 
 	fileExistsBool bool
 }
@@ -358,7 +358,7 @@ func TestInitializeProfileWhenNoFilesExist(t *testing.T) {
 func TestInitializeProfileWhenNoProfilesExist(t *testing.T) {
 	oper := &MockProfileOperationForTestInitializeProfile{
 		getProfileError: nil,
-		fileExistsBool: false,
+		fileExistsBool:  false,
 	}
 
 	err := initializeProfiles(oper)
@@ -390,7 +390,6 @@ func TestInitializeProfileWhenProfilesExist(t *testing.T) {
 		t.Errorf("Expected no profile to be set")
 	}
 }
-
 
 // ========================================================
 // TestGetProfile
@@ -450,7 +449,7 @@ func TestGetProfile(t *testing.T) {
 
 	oper := &ProfileOperation{
 		current_profile_file: "/profilename",
-		file_ops: ops,
+		file_ops:             ops,
 	}
 
 	pfile, err := oper.getProfile()
@@ -495,9 +494,9 @@ func TestGetProfile(t *testing.T) {
 
 type MockProfileFileOpsForTestSetProfile struct {
 	MockProfileFileOps
-	filesContents map[string]string
-	writtenAuth string
-	writtenToken string
+	filesContents   map[string]string
+	writtenAuth     string
+	writtenToken    string
 	writtenEndpoint string
 }
 
@@ -532,19 +531,19 @@ func TestSetProfile(t *testing.T) {
 
 	oper := &ProfileOperation{
 		current_profile_file: "/profilenamefile",
-		file_ops: ops,
+		file_ops:             ops,
 	}
 
 	pfile := profileFile{
 		Name: "testo",
 		Login: config.Login{
-			Auth: "theauth",
-			Token: "thetoken",
+			Auth:     "theauth",
+			Token:    "thetoken",
 			Endpoint: "https://theendpoint",
 		},
 		PrivateKey: "theprivatekey",
-		PublicKey : "thepublickey",
-		Cert      : "thecert",
+		PublicKey:  "thepublickey",
+		Cert:       "thecert",
 	}
 
 	err := oper.setProfile(pfile)
@@ -669,7 +668,7 @@ func TestProfilePath(t *testing.T) {
 
 type MockProfileFileOpsForTestProfileExists struct {
 	MockProfileFileOps
-	checkedFile string
+	checkedFile       string
 	assertedExistence bool
 }
 
@@ -811,7 +810,7 @@ func TestLoadProfile(t *testing.T) {
 
 type MockProfileFileOpsForTestSaveProfile struct {
 	MockProfileFileOps
-	writtenFile string
+	writtenFile  string
 	writtenBytes []byte
 }
 
@@ -828,8 +827,7 @@ func TestSaveProfile(t *testing.T) {
 		file_ops: saver,
 	}
 
-	profile := &profileFile{
-	}
+	profile := &profileFile{}
 
 	err := oper.saveProfile("hello", profile)
 
@@ -864,13 +862,13 @@ func TestSaveProfileContents(t *testing.T) {
 	profile := &profileFile{
 		Name: "hello2",
 		Login: config.Login{
-			Auth: "theauth",
-			Token: "thetoken",
+			Auth:     "theauth",
+			Token:    "thetoken",
 			Endpoint: "https://theendpoint",
 		},
 		PrivateKey: "theprivatekey",
-		PublicKey : "thepublickey",
-		Cert      : "thecert",
+		PublicKey:  "thepublickey",
+		Cert:       "thecert",
 	}
 
 	oper.saveProfile("hello2", profile)

--- a/operations/profile_operation_test.go
+++ b/operations/profile_operation_test.go
@@ -501,6 +501,52 @@ func TestGetProfile(t *testing.T) {
 	}
 }
 
+type MockProfileFileOpsForTestGetProfileWithoutCert struct {
+	MockProfileFileOpsForTestGetProfile
+}
+
+func (op MockProfileFileOpsForTestGetProfileWithoutCert) ReadFile(path string) ([]byte, error) {
+	if path == "/private.key" {
+		return []byte("aprivatekey"), nil
+	}
+
+	if path == "/public.key" {
+		return []byte("apublickey"), nil
+	}
+
+	if path == "/cert.cert" {
+		return nil, profileError{}
+	}
+
+	if path == "/profilename" {
+		return []byte("thename"), nil
+	}
+
+	return []byte(""), nil
+}
+
+// Currently we do not generate a certificate file by default, but
+// we want this mechanism to be there when we need it. This test
+// covers the current case with no certs
+func TestGetProfileWithoutCert(t *testing.T) {
+	ops := &MockProfileFileOpsForTestGetProfileWithoutCert{}
+
+	oper := &ProfileOperation{
+		current_profile_file: "/profilename",
+		file_ops:             ops,
+	}
+
+	pfile, err := oper.getProfile()
+
+	if err != nil {
+		t.Errorf("Did not expect error")
+	}
+
+	if pfile.Cert != "" {
+		t.Errorf("Expected cert to be empty but got: " + pfile.Cert)
+	}
+}
+
 // ========================================================
 // TestSetProfile
 // ========================================================

--- a/operations/profile_operation_test.go
+++ b/operations/profile_operation_test.go
@@ -1,0 +1,3 @@
+package operations
+
+import ()

--- a/operations/profile_operation_test.go
+++ b/operations/profile_operation_test.go
@@ -1,3 +1,689 @@
 package operations
 
-import ()
+import (
+	"testing"
+	"github.com/degica/barcelona-cli/config"
+)
+
+type MockProfileFileOps struct {
+}
+
+func (op MockProfileFileOps) FileExists(path string) bool {
+	return true
+}
+
+func (op MockProfileFileOps) ReadFile(path string) ([]byte, error) {
+	return []byte(""), nil
+}
+
+func (op MockProfileFileOps) WriteFile(path string, contents []byte) error {
+	return nil
+}
+
+func (op MockProfileFileOps) GetConfigDir() string {
+	return ""
+}
+
+func (op MockProfileFileOps) GetPrivateKeyPath() string {
+	return ""
+}
+
+func (op MockProfileFileOps) GetPublicKeyPath() string {
+	return ""
+}
+
+func (op MockProfileFileOps) GetCertPath() string {
+	return ""
+}
+
+func (op MockProfileFileOps) WriteLogin(auth string, token string, endpoint string) error {
+	return nil
+}
+
+func (op MockProfileFileOps) GetAuth() string {
+	return ""
+}
+
+func (op MockProfileFileOps) GetToken() string {
+	return ""
+}
+
+func (op MockProfileFileOps) GetEndpoint() string {
+	return ""
+}
+
+type MockProfileManipulation struct {
+}
+
+func (_ MockProfileManipulation) getProfile() (*profileFile, error) {
+	return nil, nil
+}
+
+func (_ MockProfileManipulation) setProfile(profileFile) error {
+	return nil
+}
+
+func (_ MockProfileManipulation) FileExists(string) bool {
+	return false
+}
+
+func (_ MockProfileManipulation) currentProfileFile() string {
+	return ""
+}
+
+func (_ MockProfileManipulation) currentProfileName() (string, error) {
+	return "", nil
+}
+
+func (_ MockProfileManipulation) saveProfile(string, *profileFile) error {
+	return nil
+}
+
+func (_ MockProfileManipulation) loadProfile(string) (*profileFile, error) {
+	return nil, nil
+}
+
+func (_ MockProfileManipulation) GetEndpoint() string {
+	return ""
+}
+
+// ========================================================
+// TestCreateProfile
+// ========================================================
+// 
+
+// ========================================================
+// TestDeleteProfile
+// ========================================================
+// 
+
+// ========================================================
+// TestUseProfile
+// ========================================================
+// 
+
+// ========================================================
+// TestInitializeProfile
+// ========================================================
+// initialize profiles if its not initialized
+
+type MockProfileOperationForTestInitializeProfile struct {
+	MockProfileManipulation
+
+	getProfileOutput profileFile
+	getProfileError error
+
+	profileThatWasSet *profileFile
+	setProfileError error
+
+	currentProfileNameString string
+	currentProfileNameError error
+
+	fileExistsBool bool
+}
+
+func (op MockProfileOperationForTestInitializeProfile) FileExists(path string) bool {
+	return op.fileExistsBool
+}
+
+func (m MockProfileOperationForTestInitializeProfile) getProfile() (*profileFile, error) {
+	return &m.getProfileOutput, m.getProfileError
+}
+
+func (m *MockProfileOperationForTestInitializeProfile) setProfile(profile profileFile) error {
+	m.profileThatWasSet = &profile
+	return m.setProfileError
+}
+
+func (m MockProfileOperationForTestInitializeProfile) currentProfileName() (string, error) {
+	return m.currentProfileNameString, m.currentProfileNameError
+}
+
+func TestInitializeProfileWhenNoFilesExist(t *testing.T) {
+	oper := &MockProfileOperationForTestInitializeProfile{
+		getProfileError: profileError{
+			error: "some error due to file load",
+		},
+		fileExistsBool: false,
+	}
+
+	err := initializeProfiles(oper)
+
+	if err != nil {
+		t.Errorf("Expected no error but got: " + err.Error())
+	}
+
+	if oper.profileThatWasSet == nil {
+		t.Errorf("Expected a profile to be set")
+	}
+}
+
+func TestInitializeProfileWhenNoProfilesExist(t *testing.T) {
+	oper := &MockProfileOperationForTestInitializeProfile{
+		getProfileError: nil,
+		fileExistsBool: false,
+	}
+
+	err := initializeProfiles(oper)
+
+	if err != nil {
+		t.Errorf("Expected no error but got: " + err.Error())
+	}
+
+	if oper.profileThatWasSet == nil {
+		t.Errorf("Expected a profile to be set")
+	}
+}
+
+func TestInitializeProfileWhenProfilesExist(t *testing.T) {
+	oper := &MockProfileOperationForTestInitializeProfile{
+		getProfileError: profileError{
+			error: "should not error",
+		},
+		fileExistsBool: true,
+	}
+
+	err := initializeProfiles(oper)
+
+	if err != nil {
+		t.Errorf("Expected no error but got: " + err.Error())
+	}
+
+	if oper.profileThatWasSet != nil {
+		t.Errorf("Expected no profile to be set")
+	}
+}
+
+
+// ========================================================
+// TestGetProfile
+// ========================================================
+// gets the current settings and assigns a name to it
+
+type MockProfileFileOpsForTestGetProfile struct {
+	MockProfileFileOps
+}
+
+func (op MockProfileFileOpsForTestGetProfile) GetPrivateKeyPath() string {
+	return "/private.key"
+}
+
+func (op MockProfileFileOpsForTestGetProfile) GetPublicKeyPath() string {
+	return "/public.key"
+}
+
+func (op MockProfileFileOpsForTestGetProfile) GetCertPath() string {
+	return "/cert.cert"
+}
+
+func (op MockProfileFileOpsForTestGetProfile) ReadFile(path string) ([]byte, error) {
+	if path == "/private.key" {
+		return []byte("aprivatekey"), nil
+	}
+
+	if path == "/public.key" {
+		return []byte("apublickey"), nil
+	}
+
+	if path == "/cert.cert" {
+		return []byte("acert"), nil
+	}
+
+	if path == "/profilename" {
+		return []byte("thename"), nil
+	}
+
+	return []byte(""), nil
+}
+
+func (op MockProfileFileOpsForTestGetProfile) GetAuth() string {
+	return "anauth"
+}
+
+func (op MockProfileFileOpsForTestGetProfile) GetToken() string {
+	return "atoken"
+}
+
+func (op MockProfileFileOpsForTestGetProfile) GetEndpoint() string {
+	return "anendpoint"
+}
+
+func TestGetProfile(t *testing.T) {
+	ops := &MockProfileFileOpsForTestGetProfile{}
+
+	oper := &ProfileOperation{
+		current_profile_file: "/profilename",
+		file_ops: ops,
+	}
+
+	pfile, err := oper.getProfile()
+
+	if err != nil {
+		t.Errorf("Did not expect error")
+	}
+
+	if pfile.Name != "thename" {
+		t.Errorf("Expected 'thename' but got: " + pfile.Name)
+	}
+
+	if pfile.PrivateKey != "aprivatekey" {
+		t.Errorf("Expected 'aprivatekey' but got: " + pfile.PrivateKey)
+	}
+
+	if pfile.PublicKey != "apublickey" {
+		t.Errorf("Expected 'apublickey' but got: " + pfile.PublicKey)
+	}
+
+	if pfile.Cert != "acert" {
+		t.Errorf("Expected 'acert' but got: " + pfile.Cert)
+	}
+
+	if pfile.Login.Auth != "anauth" {
+		t.Errorf("Expected 'anauth' but got: " + pfile.Login.Auth)
+	}
+
+	if pfile.Login.Endpoint != "anendpoint" {
+		t.Errorf("Expected 'anendpoint' but got: " + pfile.Login.Endpoint)
+	}
+
+	if pfile.Login.Token != "atoken" {
+		t.Errorf("Expected 'atoken' but got: " + pfile.Login.Token)
+	}
+}
+
+// ========================================================
+// TestSetProfile
+// ========================================================
+// sets the current settings given a profile
+
+type MockProfileFileOpsForTestSetProfile struct {
+	MockProfileFileOps
+	filesContents map[string]string
+	writtenAuth string
+	writtenToken string
+	writtenEndpoint string
+}
+
+func (op MockProfileFileOpsForTestSetProfile) GetPrivateKeyPath() string {
+	return "/privatekeyfile"
+}
+
+func (op MockProfileFileOpsForTestSetProfile) GetPublicKeyPath() string {
+	return "/publickeyfile"
+}
+
+func (op MockProfileFileOpsForTestSetProfile) GetCertPath() string {
+	return "/certfile"
+}
+
+func (op *MockProfileFileOpsForTestSetProfile) WriteFile(path string, contents []byte) error {
+	op.filesContents[path] = string(contents)
+	return nil
+}
+
+func (op *MockProfileFileOpsForTestSetProfile) WriteLogin(auth string, token string, endpoint string) error {
+	op.writtenToken = token
+	op.writtenAuth = auth
+	op.writtenEndpoint = endpoint
+	return nil
+}
+
+func TestSetProfile(t *testing.T) {
+	ops := &MockProfileFileOpsForTestSetProfile{
+		filesContents: map[string]string{},
+	}
+
+	oper := &ProfileOperation{
+		current_profile_file: "/profilenamefile",
+		file_ops: ops,
+	}
+
+	pfile := profileFile{
+		Name: "testo",
+		Login: config.Login{
+			Auth: "theauth",
+			Token: "thetoken",
+			Endpoint: "https://theendpoint",
+		},
+		PrivateKey: "theprivatekey",
+		PublicKey : "thepublickey",
+		Cert      : "thecert",
+	}
+
+	err := oper.setProfile(pfile)
+
+	if err != nil {
+		t.Errorf("Did not expect error")
+	}
+
+	if ops.filesContents["/privatekeyfile"] != "theprivatekey" {
+		t.Errorf("Expected privatekeyfile to contain 'theprivatekey' instead got: " + ops.filesContents["/privatekeyfile"])
+	}
+
+	if ops.filesContents["/publickeyfile"] != "thepublickey" {
+		t.Errorf("Expected publickeyfile to contain 'thepublickey' instead got: " + ops.filesContents["/publickeyfile"])
+	}
+
+	if ops.filesContents["/certfile"] != "thecert" {
+		t.Errorf("Expected certfile to contain 'thecert' instead got: " + ops.filesContents["/certfile"])
+	}
+
+	if ops.filesContents["/profilenamefile"] != "testo" {
+		t.Errorf("Expected profilenamefile to contain 'testo' instead got: " + ops.filesContents["/profilenamefile"])
+	}
+
+	if ops.writtenAuth != "theauth" {
+		t.Errorf("Expected writtenAuth to contain 'theauth' instead got: " + ops.writtenAuth)
+	}
+
+	if ops.writtenToken != "thetoken" {
+		t.Errorf("Expected writtenToken to contain 'thetoken' instead got: " + ops.writtenToken)
+	}
+
+	if ops.writtenEndpoint != "https://theendpoint" {
+		t.Errorf("Expected writtenEndpoint to contain 'https://theendpoint' instead got: " + ops.writtenEndpoint)
+	}
+}
+
+// ========================================================
+// TestCurrentProfileName
+// ========================================================
+
+type MockProfileFileOpsForTestCurrentProfileName struct {
+	MockProfileFileOps
+	profileExists bool
+}
+
+func (op *MockProfileFileOpsForTestCurrentProfileName) FileExists(name string) bool {
+	return op.profileExists
+}
+
+func (op MockProfileFileOpsForTestCurrentProfileName) ReadFile(path string) ([]byte, error) {
+	return []byte("profilename"), nil
+}
+
+func TestCurrentProfileNameWhenNoneExists(t *testing.T) {
+	ops := &MockProfileFileOpsForTestCurrentProfileName{}
+	ops.profileExists = false
+
+	oper := &ProfileOperation{
+		file_ops: ops,
+	}
+
+	name, err := oper.currentProfileName()
+
+	if err != nil {
+		t.Errorf("Expected no error but got: " + err.Error())
+	}
+
+	if name != "default" {
+		t.Errorf("Expected 'default' but got: " + name)
+	}
+}
+
+func TestCurrentProfileNameWhenOneExists(t *testing.T) {
+	ops := &MockProfileFileOpsForTestCurrentProfileName{}
+	ops.profileExists = true
+
+	oper := &ProfileOperation{
+		file_ops: ops,
+	}
+
+	name, err := oper.currentProfileName()
+
+	if err != nil {
+		t.Errorf("Expected no error but got: " + err.Error())
+	}
+
+	if name != "profilename" {
+		t.Errorf("Expected 'profilename' but got: " + name)
+	}
+}
+
+// ========================================================
+// TestProfilePath
+// ========================================================
+
+type MockProfileFileOpsForTestProfilePath struct {
+	MockProfileFileOps
+}
+
+func (op MockProfileFileOpsForTestProfilePath) GetConfigDir() string {
+	return "/something"
+}
+
+func TestProfilePath(t *testing.T) {
+	ops := &MockProfileFileOpsForTestProfilePath{}
+
+	oper := &ProfileOperation{
+		file_ops: ops,
+	}
+
+	profilePath := oper.profilePath("abc")
+
+	if profilePath != "/something/profile_abc" {
+		t.Errorf("Expected '/something/profile_abc' but got: " + profilePath)
+	}
+}
+
+// ========================================================
+// TestProfileExists
+// ========================================================
+
+type MockProfileFileOpsForTestProfileExists struct {
+	MockProfileFileOps
+	checkedFile string
+	assertedExistence bool
+}
+
+func (op *MockProfileFileOpsForTestProfileExists) FileExists(name string) bool {
+	op.checkedFile = name
+	return op.assertedExistence
+}
+
+func TestProfileExists(t *testing.T) {
+	ops := &MockProfileFileOpsForTestProfileExists{}
+
+	oper := &ProfileOperation{
+		file_ops: ops,
+	}
+
+	oper.profileExists("foobar")
+
+	if ops.checkedFile != "profile_foobar" {
+		t.Errorf("Expected 'profile_foobar' but got: " + ops.checkedFile)
+	}
+}
+
+func TestProfileExistsReturnsResultOfFileExists(t *testing.T) {
+	ops := &MockProfileFileOpsForTestProfileExists{}
+
+	oper := &ProfileOperation{
+		file_ops: ops,
+	}
+
+	ops.assertedExistence = true
+	trueResult := oper.profileExists("foobar")
+
+	if trueResult != true {
+		t.Errorf("FileExists returned true but profileExists returned false")
+	}
+
+	ops.assertedExistence = false
+	falseResult := oper.profileExists("foobar")
+
+	if falseResult != false {
+		t.Errorf("FileExists returned false but profileExists returned true")
+	}
+}
+
+// ========================================================
+// TestLoadNonexistentProfile
+// ========================================================
+
+type MockProfileFileOpsForTestLoadNonexistentProfile struct {
+	MockProfileFileOps
+}
+
+func (op MockProfileFileOpsForTestLoadNonexistentProfile) FileExists(path string) bool {
+	return false
+}
+
+func TestLoadNonexistentProfile(t *testing.T) {
+	loader := &MockProfileFileOpsForTestLoadNonexistentProfile{}
+
+	oper := &ProfileOperation{
+		file_ops: loader,
+	}
+
+	_, err := oper.loadProfile("idontexist")
+
+	if err == nil {
+		t.Errorf("Should throw an error")
+		return
+	}
+
+	if err.Error() != "profile idontexist does not exist" {
+		t.Errorf("Shuold throw an error 'profile idontexist does not exist' but got: " + err.Error())
+	}
+}
+
+// ========================================================
+// TestLoadProfile
+// ========================================================
+
+type MockProfileFileOpsForTestLoadProfile struct {
+	MockProfileFileOps
+	readFile string
+}
+
+func (op *MockProfileFileOpsForTestLoadProfile) ReadFile(path string) ([]byte, error) {
+	op.readFile = path
+	return []byte(`{"name":"hello2","login":{"auth":"theauth","token":"thetoken","endpoint":"theendpoint"},"privateKey":"theprivatekey","publicKey":"thepublickey","cert":"thecert"}`), nil
+}
+
+func TestLoadProfile(t *testing.T) {
+	loader := &MockProfileFileOpsForTestLoadProfile{}
+
+	oper := &ProfileOperation{
+		file_ops: loader,
+	}
+
+	profile, err := oper.loadProfile("theprofile")
+
+	if err != nil {
+		t.Errorf("Threw an error: " + err.Error())
+	}
+
+	if loader.readFile != "profile_theprofile" {
+		t.Errorf("Read the wrong file: " + loader.readFile)
+	}
+
+	if profile.Name != "hello2" {
+		t.Errorf("Expected Name to be 'hello2' but got " + profile.Name)
+	}
+
+	if profile.PrivateKey != "theprivatekey" {
+		t.Errorf("Expected PrivateKey to be 'theprivatekey' but got " + profile.PrivateKey)
+	}
+
+	if profile.PublicKey != "thepublickey" {
+		t.Errorf("Expected PublicKey to be 'thepublickey' but got " + profile.PublicKey)
+	}
+
+	if profile.Cert != "thecert" {
+		t.Errorf("Expected Cert to be 'thecert' but got " + profile.Cert)
+	}
+
+	if profile.Login.Auth != "theauth" {
+		t.Errorf("Expected Auth to be 'theauth' but got " + profile.Login.Auth)
+	}
+
+	if profile.Login.Endpoint != "theendpoint" {
+		t.Errorf("Expected Endpoint to be 'theendpoint' but got " + profile.Login.Endpoint)
+	}
+
+	if profile.Login.Token != "thetoken" {
+		t.Errorf("Expected Token to be 'thetoken' but got " + profile.Login.Token)
+	}
+}
+
+// ========================================================
+// TestSaveProfile
+// ========================================================
+
+type MockProfileFileOpsForTestSaveProfile struct {
+	MockProfileFileOps
+	writtenFile string
+	writtenBytes []byte
+}
+
+func (op *MockProfileFileOpsForTestSaveProfile) WriteFile(path string, contents []byte) error {
+	op.writtenFile = path
+	op.writtenBytes = contents
+	return nil
+}
+
+func TestSaveProfile(t *testing.T) {
+	saver := &MockProfileFileOpsForTestSaveProfile{}
+
+	oper := &ProfileOperation{
+		file_ops: saver,
+	}
+
+	profile := &profileFile{
+	}
+
+	err := oper.saveProfile("hello", profile)
+
+	if err != nil {
+		t.Errorf("Threw an error: " + err.Error())
+	}
+
+	if saver.writtenBytes == nil {
+		t.Errorf("writtenBytes nil")
+	}
+}
+
+// ========================================================
+// TestSaveProfileContents
+// ========================================================
+
+type MockProfileFileOpsForTestSaveProfileContents struct {
+	MockProfileFileOpsForTestSaveProfile
+}
+
+func (op MockProfileFileOpsForTestSaveProfileContents) GetConfigDir() string {
+	return "/home/test/bcn/configdir"
+}
+
+func TestSaveProfileContents(t *testing.T) {
+	saver := &MockProfileFileOpsForTestSaveProfileContents{}
+
+	oper := &ProfileOperation{
+		file_ops: saver,
+	}
+
+	profile := &profileFile{
+		Name: "hello2",
+		Login: config.Login{
+			Auth: "theauth",
+			Token: "thetoken",
+			Endpoint: "https://theendpoint",
+		},
+		PrivateKey: "theprivatekey",
+		PublicKey : "thepublickey",
+		Cert      : "thecert",
+	}
+
+	oper.saveProfile("hello2", profile)
+
+	writtenContent := string(saver.writtenBytes)
+	if writtenContent != `{"name":"hello2","login":{"auth":"theauth","token":"thetoken","endpoint":"https://theendpoint"},"privateKey":"theprivatekey","publicKey":"thepublickey","cert":"thecert"}` {
+		t.Errorf("writtenbytes was " + writtenContent)
+	}
+
+	if saver.writtenFile != "/home/test/bcn/configdir/profile_hello2" {
+		t.Errorf("Saved to wrong file: " + saver.writtenFile)
+	}
+}

--- a/operations/sshcmd_operation_test.go
+++ b/operations/sshcmd_operation_test.go
@@ -14,15 +14,15 @@ func (m MockSshcmdOperationApiClient) Post(path string, body io.Reader) ([]byte,
 type MockSshcmdOperationConfig struct {
 }
 
-func (m MockSshcmdOperationConfig) GetCertPath() (string) {
+func (m MockSshcmdOperationConfig) GetCertPath() string {
 	return ""
 }
 
-func (m MockSshcmdOperationConfig) GetPrivateKeyPath() (string) {
+func (m MockSshcmdOperationConfig) GetPrivateKeyPath() string {
 	return ""
 }
 
-func (m MockSshcmdOperationConfig) IsDebug() (bool) {
+func (m MockSshcmdOperationConfig) IsDebug() bool {
 	return false
 }
 
@@ -32,7 +32,6 @@ type MockSshcmdOperationCommandRunner struct {
 func (m MockSshcmdOperationCommandRunner) RunCommand(name string, arg ...string) error {
 	return nil
 }
-
 
 func ExampleSshcmdOperation_run_output() {
 	client := &MockSshcmdOperationApiClient{}

--- a/utils/file_ops.go
+++ b/utils/file_ops.go
@@ -16,3 +16,8 @@ func (_ FileOps) FileExists(path string) bool {
 func (_ FileOps) ReadFile(path string) ([]byte, error) {
 	return ioutil.ReadFile(path)
 }
+
+func (_ FileOps) WriteFile(path string, content []byte) (error) {
+	return ioutil.WriteFile(path, content, 0600)
+}
+

--- a/utils/file_ops.go
+++ b/utils/file_ops.go
@@ -17,7 +17,6 @@ func (_ FileOps) ReadFile(path string) ([]byte, error) {
 	return ioutil.ReadFile(path)
 }
 
-func (_ FileOps) WriteFile(path string, content []byte) (error) {
+func (_ FileOps) WriteFile(path string, content []byte) error {
 	return ioutil.WriteFile(path, content, 0600)
 }
-


### PR DESCRIPTION
This PR adds a new `profiles` command to bcn cli.

## How to test
There's a bunch of things to do here.

First rename `~/.bcn` to something else, or copy it somewhere to back it up.

### Create
1. Delete `rm -rf ~/.bcn`
2. Run `./bcn profile create titan`
3. Should show you something like `open /Users/davidsiaw/.bcn/id_ecdsa: no such file or directory`

Restore your original `~/.bcn`

1. Run `./bcn profile create titan`
2. Check that `./bcn profile show` returns `titan`
3. Modify the `~/.bcn/login` file's URL to be something else like `titan.com`
4. `./bcn profile use default`
5. Check that `./bcn profile show` returns `default` and the original URL
6. `./bcn profile use titan` again
7. Check that `./bcn profile show` returns `titan` and shows your modified URL
