### PR TITLE
Fix a null ref error when SSH session disconnects

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -162,7 +162,7 @@ var RunCommand = cli.Command{
 			&utils.CommandRunner{},
 		)
 
-		if ssh.Run(oneoff.InteractiveRunCommand) != nil {
+		if ssh.Run(oneoff.InteractiveRunCommand) != nil && err != nil {
 			return cli.NewExitError(err.Error(), 1)
 		}
 


### PR DESCRIPTION
Fixes a null ref error that you would get if you unplugged your network while still in a bcn run

## How to test
1. `bcn run -e someenv bash`
2. Pull your wifi
3. Tap enter a few times to try to communicate to it (it will break)
4. Observe that it will not throw a null reference exception
