### PR TITLE
display error when  public flag is set after endpoint

### DIFF
--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -40,11 +40,14 @@ var EndpointCommand = cli.Command{
 				},
 			},
 			Action: func(c *cli.Context) error {
-				if len(c.Args()) != 1 {
-					return cli.NewExitError("endpoint is invalid", 1)
+				endpointName := c.Args().Get(0)
+				if len(endpointName) == 0 {
+					return cli.NewExitError("endpoint name is required", 1)
 				}
 
-				endpointName := c.Args().First()
+				if len(c.Args()) != 1 {
+					return cli.NewExitError("please place options and flags before the endpoint name.", 1)
+				}
 
 				public := c.Bool("public")
 				request := api.Endpoint{

--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -40,10 +40,11 @@ var EndpointCommand = cli.Command{
 				},
 			},
 			Action: func(c *cli.Context) error {
-				endpointName := c.Args().Get(0)
-				if len(endpointName) == 0 {
-					return cli.NewExitError("endpoint name is required", 1)
+				if len(c.Args()) != 1 {
+					return cli.NewExitError("endpoint is invalid", 1)
 				}
+
+				endpointName := c.Args().First()
 
 				public := c.Bool("public")
 				request := api.Endpoint{


### PR DESCRIPTION
## Context
<!-- Please reference an issue and include a description -->

Fixes https://github.com/degica/barcelona-cli/issues/16

If you create an endpoint and mark it as public after the endpoint name, it comes back as Public: false.

This happens because after the endpoint, if you set the flag, you can't get the value with  `public := c.Bool("public")`
So in that case I decided to show error message.

## How to test
<!-- Include instructions on how to test your PR -->
1. it should show an error if flag is set after endpoint
`bcn endpoint create --district=hello something --public`
2. it should show an error if endpoint is empty
`bcn endpoint create --district=hello`
3. make sure if this works
`bcn endpoint create --district=hello --public something`