### PR TITLE
Do not auto refresh if VaultToken is empty

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -163,7 +163,7 @@ func dump(dump []byte, err error) {
 
 func (cli *Client) autoRefreshVaultToken() error {
 	login := config.Get().LoadLogin()
-	if login.Auth != "vault" || login.VaultUrl == "" && login.VaultToken == "" {
+	if login.Auth != "vault" || login.VaultUrl == "" || login.VaultToken == "" {
 		return nil
 	}
 


### PR DESCRIPTION
Continuation of https://github.com/degica/barcelona-cli/pull/58

I made a mistake in the condition of Auto refresh.
This caused an error to occur for existing users.
If the existing user did not execute the login command again., auto refresh should not be executed.

## How to test.
1. go build 
2.  `<path to the build>` run review list in your project
see if there is not error happens.