### PR TITLE
temporarily fix the segfault

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -216,6 +216,10 @@ LOOP:
 		}
 	}
 
+	if matchedCI == nil {
+		return cli.NewExitError("Failed to find the container. Maybe try again")
+	}
+
 	ssh := utils.NewSshCommand(
 		matchedCI.PrivateIPAddress,
 		oneoff.District.BastionIP,


### PR DESCRIPTION
A segfault can happen when the oneoff container is not returned. Will need to investigate further.