### PR TITLE
Make CLI give better errors

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -91,9 +91,6 @@ func (cli *Client) rawRequest(req *http.Request) ([]byte, error) {
 
 		if err != nil {
 			// Not a JSON error
-			//fmt.Printf("Failed to parse error. Use `bcn -d` to see raw server response\n")
-			//return nil, err
-
 			resstr := "HTTP Error:" + resp.Status + "\nType bcn -d <command> for details"
 
 			apiErr = APIError{resstr, string(b[:]), []string{}}

--- a/api/client.go
+++ b/api/client.go
@@ -69,6 +69,7 @@ func (cli *Client) rawRequest(req *http.Request) ([]byte, error) {
 	}
 
 	resp, err := cli.config.HttpClient.Do(req)
+
 	if err != nil {
 		return nil, err
 	}
@@ -87,9 +88,15 @@ func (cli *Client) rawRequest(req *http.Request) ([]byte, error) {
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		var apiErr APIError
 		err := json.Unmarshal(b, &apiErr)
+
 		if err != nil {
-			fmt.Printf("Failed to parse error. Use `bcn -d` to see raw server response\n")
-			return nil, err
+			// Not a JSON error
+			//fmt.Printf("Failed to parse error. Use `bcn -d` to see raw server response\n")
+			//return nil, err
+
+			resstr := "HTTP Error:" + resp.Status + "\nType bcn -d <command> for details"
+
+			apiErr = APIError{resstr, string(b[:]), []string{}}
 		}
 
 		return b, &apiErr

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -124,10 +124,10 @@ func TestMarshalEnvironmentHash(t *testing.T) {
 	s1 := `{"name":"TESTVAR","ssm_path":"hello/testvar1"}`
 	s2 := `{"name":"TESTVAR2","ssm_path":"hello/testvar2"}`
 	expectation1 := fmt.Sprintf("[%s,%s]", s1, s2)
-	expectation2 := fmt.Sprintf("[%s,%s]", s1, s2)
+	expectation2 := fmt.Sprintf("[%s,%s]", s2, s1)
 
 	bytes, _ := json.Marshal(heritage.Environment)
-	if str := string(bytes[:]); str != expectation1 || str != expectation2 {
-		t.Errorf("Expected '%s' or '%s' but got: %s", expectation1, expectation2, str)
+	if str := string(bytes[:]); str != expectation1 && str != expectation2 {
+		t.Errorf("Expected \n'%s' \nor \n'%s' \nbut got: \n'%s'", expectation1, expectation2, str)
 	}
 }


### PR DESCRIPTION
If you attempt to connect somewhere that no longer exists like

`bcn login http://doghouse.snoopy` <- this used to work but now does not

and try

`bcn district list`

Instead of getting

```
Failed to parse error. Use `bcn -d` to see raw server response
invalid character '<' looking for beginning of value
```

This PR gives you

```
HTTP Error:503 Service Temporarily Unavailable
Type bcn -d <command> for details
```