### PR TITLE
Update usage of deprecated set-output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Get Version
         id: getver
-        run: |
-          output=`cat VERSION`
-          echo "::set-output name=VERSION::$output"
+        run: echo "VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
       - name: Build project
         run: |
           git config --global --add safe.directory $PWD


### PR DESCRIPTION
GitHub has deprecated the usage of `set-output` syntax and advised user to pipe the output to `$GITHUB_OUTPUT` file instead: https://github.blog/changelog/2022-10-10-github-actions-deprecating-save-state-and-set-output-commands/

Note that the removal of this usage has been postponed for quite a few times, but we don't know when GitHub will pull this. So, it's best to just fix this.